### PR TITLE
Using results from osm-compare as features

### DIFF
--- a/notebooks/Use compare function results.ipynb
+++ b/notebooks/Use compare function results.ipynb
@@ -1,0 +1,658 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use compare function results\n",
+    "- This is a 💥 idea. Thank you once again @anandthakker!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%config InlineBackend.figure_format = 'retina'\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bkowshik/anaconda/lib/python3.5/site-packages/sklearn/learning_curve.py:23: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the functions are moved. This module will be removed in 0.20\n",
+      "  DeprecationWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn import preprocessing\n",
+    "from sklearn.svm import SVC\n",
+    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.metrics import classification_report\n",
+    "from sklearn.cross_validation import cross_val_score\n",
+    "from sklearn.learning_curve import learning_curve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(64248, 19)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>user</th>\n",
+       "      <th>editor</th>\n",
+       "      <th>Powerfull Editor</th>\n",
+       "      <th>comment</th>\n",
+       "      <th>source</th>\n",
+       "      <th>imagery used</th>\n",
+       "      <th>date</th>\n",
+       "      <th>reasons</th>\n",
+       "      <th>reasons__name</th>\n",
+       "      <th>create</th>\n",
+       "      <th>modify</th>\n",
+       "      <th>delete</th>\n",
+       "      <th>bbox</th>\n",
+       "      <th>is suspect</th>\n",
+       "      <th>harmful</th>\n",
+       "      <th>checked</th>\n",
+       "      <th>check_user__username</th>\n",
+       "      <th>check date</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>62639</th>\n",
+       "      <td>37207529</td>\n",
+       "      <td>Silent7</td>\n",
+       "      <td>JOSM/1.5 (9329 ru)</td>\n",
+       "      <td>True</td>\n",
+       "      <td>леса; молодые леса</td>\n",
+       "      <td>Bing</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>2016-02-14T16:52:00+00:00</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>possible import</td>\n",
+       "      <td>306.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>SRID=4326;POLYGON ((54.9652697 58.3497383, 54....</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>andygol</td>\n",
+       "      <td>2016-04-07T12:29:22.344002+00:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45473</th>\n",
+       "      <td>43193824</td>\n",
+       "      <td>flockfinder</td>\n",
+       "      <td>Go Map!! 1.4</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Added tags</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>2016-10-26T14:15:29+00:00</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>edited a name tag</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>61.0</td>\n",
+       "      <td>SRID=4326;POLYGON ((-118.1686082 34.7231313, -...</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "      <td>dannykath</td>\n",
+       "      <td>2016-11-29T15:55:20.227959+00:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             ID         user              editor Powerfull Editor  \\\n",
+       "62639  37207529      Silent7  JOSM/1.5 (9329 ru)             True   \n",
+       "45473  43193824  flockfinder        Go Map!! 1.4            False   \n",
+       "\n",
+       "                  comment        source  imagery used  \\\n",
+       "62639  леса; молодые леса          Bing  Not reported   \n",
+       "45473          Added tags  Not reported  Not reported   \n",
+       "\n",
+       "                            date  reasons      reasons__name  create  modify  \\\n",
+       "62639  2016-02-14T16:52:00+00:00      2.0    possible import   306.0     0.0   \n",
+       "45473  2016-10-26T14:15:29+00:00     13.0  edited a name tag     6.0     5.0   \n",
+       "\n",
+       "       delete                                               bbox is suspect  \\\n",
+       "62639     0.0  SRID=4326;POLYGON ((54.9652697 58.3497383, 54....       True   \n",
+       "45473    61.0  SRID=4326;POLYGON ((-118.1686082 34.7231313, -...       True   \n",
+       "\n",
+       "      harmful checked check_user__username                        check date  \n",
+       "62639   False    True              andygol  2016-04-07T12:29:22.344002+00:00  \n",
+       "45473   False    True            dannykath  2016-11-29T15:55:20.227959+00:00  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "changesets = pd.read_csv('../data/use-compare-function-results/changesets.csv')\n",
+    "print(changesets.shape)\n",
+    "changesets.sample(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Some numbers on \"reasons\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Changests with atleast one reason: 26990\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How many changesets have atleast one reason?\n",
+    "reason_changesets = changesets[changesets['reasons__name'].isnull() == False].drop_duplicates('ID')\n",
+    "print('Changests with atleast one reason: {}'.format(reason_changesets.shape[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Changests without a reason: 32257\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How many changesets have no reasons?\n",
+    "no_reason_changesets = changesets[changesets['reasons__name'].isnull()].drop_duplicates('ID')\n",
+    "print('Changests without a reason: {}'.format(no_reason_changesets.shape[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Major name modification' 'New mapper' 'suspect_word'\n",
+      " 'Added invalid highway tag' 'possible import' 'Invalid tag modification'\n",
+      " 'Edited a place' 'mass deletion' 'Flagged by gabbar'\n",
+      " 'Edited an osm landmark' 'Edited a major lake' 'mass modification'\n",
+      " 'New footway created' 'Invalid key value combination'\n",
+      " 'Edited a major road' 'Unknown iD instance' 'Feature with Pokename'\n",
+      " 'Added a large building' 'Edited an old monument'\n",
+      " 'Added a new place(city/town/country)' 'Deleted a wikidata/wikipedia tag'\n",
+      " 'Software editor was not declared' 'Feature near Null Island'\n",
+      " 'Dragged highway/waterway' 'Edited a place wikidata' 'edited a name tag'\n",
+      " 'Edited an object having disputed tag'\n",
+      " 'Edited a landmark wikidata/wikipedia' 'Edited a path road'\n",
+      " 'Deleted a wikidata tag' 'edited a wikipedia' 'edited a database wikidata'\n",
+      " 'edited a wikidata' 'edited a database wikipedia' 'Invalid relation'\n",
+      " 'edited an object with a significant tag'\n",
+      " 'moved an object a significant amount'\n",
+      " 'edited an object with a significant place tag'\n",
+      " 'edited a wikipedia landmark']\n",
+      "Number of reasons: 39\n"
+     ]
+    }
+   ],
+   "source": [
+    "reasons = changesets['reasons__name'].dropna().drop_duplicates().values\n",
+    "print(reasons)\n",
+    "print('Number of reasons: {}'.format(len(reasons)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert \"reasons\" to a numerical value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "for reason in reasons:\n",
+    "    changesets[reason] = (changesets['reasons__name'] == reason).apply(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(64248, 58)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>user</th>\n",
+       "      <th>editor</th>\n",
+       "      <th>Powerfull Editor</th>\n",
+       "      <th>comment</th>\n",
+       "      <th>source</th>\n",
+       "      <th>imagery used</th>\n",
+       "      <th>date</th>\n",
+       "      <th>reasons</th>\n",
+       "      <th>reasons__name</th>\n",
+       "      <th>...</th>\n",
+       "      <th>Deleted a wikidata tag</th>\n",
+       "      <th>edited a wikipedia</th>\n",
+       "      <th>edited a database wikidata</th>\n",
+       "      <th>edited a wikidata</th>\n",
+       "      <th>edited a database wikipedia</th>\n",
+       "      <th>Invalid relation</th>\n",
+       "      <th>edited an object with a significant tag</th>\n",
+       "      <th>moved an object a significant amount</th>\n",
+       "      <th>edited an object with a significant place tag</th>\n",
+       "      <th>edited a wikipedia landmark</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>47491144</td>\n",
+       "      <td>RichRico</td>\n",
+       "      <td>JOSM/1.5 (11639 en)</td>\n",
+       "      <td>True</td>\n",
+       "      <td>Adding junction nodes or bridges to overlappin...</td>\n",
+       "      <td>Bing</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>2017-04-05T22:46:26+00:00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>47490912</td>\n",
+       "      <td>Birgitta_fi</td>\n",
+       "      <td>rosemary v0.4.4</td>\n",
+       "      <td>False</td>\n",
+       "      <td>Modified via wheelmap.org</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>Not reported</td>\n",
+       "      <td>2017-04-05T22:27:45+00:00</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>Major name modification</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2 rows × 58 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         ID         user               editor Powerfull Editor  \\\n",
+       "0  47491144     RichRico  JOSM/1.5 (11639 en)             True   \n",
+       "1  47490912  Birgitta_fi      rosemary v0.4.4            False   \n",
+       "\n",
+       "                                             comment        source  \\\n",
+       "0  Adding junction nodes or bridges to overlappin...          Bing   \n",
+       "1                          Modified via wheelmap.org  Not reported   \n",
+       "\n",
+       "   imagery used                       date  reasons            reasons__name  \\\n",
+       "0  Not reported  2017-04-05T22:46:26+00:00      NaN                      NaN   \n",
+       "1  Not reported  2017-04-05T22:27:45+00:00     23.0  Major name modification   \n",
+       "\n",
+       "              ...               Deleted a wikidata tag  edited a wikipedia  \\\n",
+       "0             ...                                    0                   0   \n",
+       "1             ...                                    0                   0   \n",
+       "\n",
+       "   edited a database wikidata edited a wikidata edited a database wikipedia  \\\n",
+       "0                           0                 0                           0   \n",
+       "1                           0                 0                           0   \n",
+       "\n",
+       "  Invalid relation edited an object with a significant tag  \\\n",
+       "0                0                                       0   \n",
+       "1                0                                       0   \n",
+       "\n",
+       "  moved an object a significant amount  \\\n",
+       "0                                    0   \n",
+       "1                                    0   \n",
+       "\n",
+       "  edited an object with a significant place tag  edited a wikipedia landmark  \n",
+       "0                                             0                            0  \n",
+       "1                                             0                            0  \n",
+       "\n",
+       "[2 rows x 58 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(changesets.shape)\n",
+    "changesets.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reason: edited a wikipedia landmark\n",
+      "Changesets with reason are: 520\n",
+      "Numerical sum of changesets with reason: 520\n"
+     ]
+    }
+   ],
+   "source": [
+    "# If the numbers match then Yay!\n",
+    "print('Reason: {}'.format(reason))\n",
+    "print('Changesets with reason are: {}'.format(changesets[changesets['reasons__name'] == reason].shape[0]))\n",
+    "print('Numerical sum of changesets with reason: {}'.format(changesets[reason].sum()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train a ML model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "columns = ['create', 'modify', 'delete', 'harmful']\n",
+    "columns.extend(reasons)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Extract all features used for training the ML model.\n",
+    "features = changesets[columns]\n",
+    "features = features.dropna()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Scale features using RobustScaler that handles outliers better.\n",
+    "X = features.drop('harmful', axis=1)\n",
+    "scaler = preprocessing.RobustScaler().fit(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "X = scaler.transform(features.drop('harmful', axis=1))\n",
+    "y = features['harmful']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(44844, 42) (19219, 42)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Split dataset into random train and test subsets.\n",
+    "Xtrain, Xtest, ytrain, ytest = train_test_split(\n",
+    "    X,\n",
+    "    y,\n",
+    "    train_size=0.7,\n",
+    "    random_state=1\n",
+    ")\n",
+    "print(Xtrain.shape, Xtest.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "\n",
+    "model = SVC(kernel='rbf')\n",
+    "model.fit(Xtrain, ytrain)\n",
+    "y_model = model.predict(Xtest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                 precision    recall  f1-score   support\n",
+      "\n",
+      "    problematic       0.75      0.00      0.01      1731\n",
+      "not problematic       0.91      1.00      0.95     17488\n",
+      "\n",
+      "    avg / total       0.90      0.91      0.87     19219\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Performance of model.\n",
+    "print(classification_report(ytest, y_model, labels=[True, False], target_names=['problematic', 'not problematic']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.90348556695920912"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Evaluate a score by cross-validation.\n",
+    "scores = cross_val_score(model, X, y, cv=3)\n",
+    "np.mean(scores)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABiAAAAQvCAYAAACe1iZxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAewgAAHsIBbtB1PgAAIABJREFUeJzs3Xl4VOXd//HPmUkmM5NAAggC7sUFUREsFREQqnWpVMGl\nKNoqYqsCQbDytNVf28fHLrZqFQRRUagLggX31l0EKlBQVFzABVFEWQMkZJtJZjm/P4aZzGTWZCaT\nZPJ+XVeuOTPnPud8zyyQnM/c922YpmkKAAAAAAAAAAAggyytXQAAAAAAAAAAAMg9BBAAAAAAAAAA\nACDjCCAAAAAAAAAAAEDGEUAAAAAAAAAAAICMI4AAAAAAAAAAAAAZRwABAAAAAAAAAAAyjgACAAAA\nAAAAAABkHAEEAAAAAAAAAADIOAIIAAAAAAAAAACQcQQQAAAAAAAAAAAg4wggAAAAAAAAAABAxhFA\nAAAAAAAAAACAjCOAAAAAAAAAAAAAGUcAAQAAAAAAAAAAMo4AAgAAAAAAAAAAZBwBBAAAAAAAAAAA\nyDgCCAAAAAAAAAAAkHEEEAAAAAAAAAAAIOMIIAAAAAAAAAAAQMYRQAAAAAAZMHv2bPXt21d9+/bV\nLbfc0trl5ITnnnsu9JzOnj27tcsBAAAA0EQEEAAAAEAGGYbR2iXkHJ5TAAAAoH0igAAAAADQZhE+\nAAAAAO1XXmsXAAAAAACxXHTRRbroootauwwAAAAAzUQPCAAAAAAAAAAAkHEEEAAAAAAAAAAAIOMY\nggkAAABow1atWqV///vfWrdunfbs2SPDMNSjRw+deuqpuvTSS9W/f/+U9vPJJ5/o5Zdf1rp167R9\n+3bt379f+fn5Ki4uVt++fTVixAhdfPHFstlsMbfv27evJOnyyy/XbbfdpkWLFunRRx/Vzp07ddBB\nB2nQoEGaNm2aevXqpTPPPFPbt2/X8OHD9fDDD6u6ulqLFi3SG2+8oa1bt8rlcqlHjx467bTTNG7c\nOPXr1y/mMZ977jndcsstkqTS0lKVlpYmrGnPnj168skntWzZMm3fvl0ej0c9e/bUsGHD9POf/1yH\nH3540udp48aNWrBggd555x3t2rVLTqdTffr00YUXXqif/vSnKi8v17BhwyQFhoi64447Unr+49m6\ndasWL16sVatW6ZtvvlF9fb1KSkp0wgkn6Cc/+YlGjRoliyXye2Pbtm3TWWedJUk69dRT9fjjjyc8\nRvB5OuSQQ7R06dKIdbfccouee+45FRQU6MMPP9Rnn32mv/3tb1q/fr0cDoeOOeYYDR8+XHfffbck\nqWvXrlq5cmVUTY3dfPPNeumllyRJd955py688MKoNjt37tRTTz2llStX6rvvvlNNTY26dOmifv36\n6eyzz9bo0aOVl8efrAAAAO0Zv80BAAAAbdD+/fv1q1/9SqtWrZIUORnzN998oy1btmjx4sW66KKL\n9H//939xg4Oamhr95je/0Ztvvhm1H6/XK5fLpR07dmjZsmV65JFH9Mgjj+jII4+Mua/gto8++qj+\n+te/hh7ftm2bdu/erd/97ndRbTds2KDS0lLt2LEj4tjffvutvv32Wz3zzDOaOnWqrr/++rjPRaKJ\nqIPrVq5cqZtvvln79++PaP/111/r66+/1lNPPaU//vGPGjNmTNx9zZkzR7NmzZJpmqF9VFZW6v33\n39f777+vp59+Wn/+85+T1pQK0zR1zz33aP78+fL5fBH73Lt3r1asWKEVK1bo8ccf15w5c9S9e/e4\n556KVNp+++23+vnPf66qqipJksvl0jvvvKNzzjlHAwYM0Pr161VeXq7Vq1eHQphY3G633nrrLRmG\nIYfDoXPOOSeqzfz58zVz5kzV1dVF1FdWVqbly5dr+fLlmjt3rmbNmqVjjz025fMEAABA20IAAQAA\nALQxlZWVuuyyy7RlyxYZhiG73a4zzzxTRx99tHw+nz799FP95z//kdfr1XPPPacdO3Zo/vz5Ud9K\nN01T1157rdavXx/az4gRI3T00UeroKBA5eXlevfdd/XJJ59ICgQJ06ZN0/PPPx+3ti1btuiZZ56J\nuqB9+umnq1OnThGP7dy5U9ddd5327dun7t2766yzzlLv3r1VVlam1157TWVlZfL7/ZoxY4ZOPPFE\nDR06tFnP16effqoXXnhBbrdbhx12mEaOHKnu3btr27ZtevXVV1VZWSmPx6Pf/e53Oumkk9SnT5+o\nfcyYMUMPPvigDMOQYRjq37+/Tj/9dFmtVq1fv16rV6/Whg0bNHHixGbV2Nitt96q5557LnS8Y489\nVkOHDlVRUZG++uorvf766/J4PPr44481YcIEPfPMM3FDpkz53e9+p6qqqojX1mKx6Nxzz5VhGFq/\nfr0k6aWXXkoYQLz11ltyuVwyDEPnnnuu7HZ7xPq77rpL8+bNC537gAED9IMf/EBFRUXatm2bli9f\nrt27d+ubb77RFVdcoSeffFLHHXdcy5w0AAAAWhQBBAAAANDG3HrrraHwYejQobrzzjvVtWvXiDZb\nt25VaWmpvvjiC61du1Zz5syJGqLo2WefDYUPvXv31oIFC9SrV6+o47388suaPn26/H6/Pv/8c61b\nt06DBg2KWduaNWtkGIYuueQSTZo0SSUlJXrvvfeUn58f1XbTpk0yDEOXX365brnllogL6NOnT9ek\nSZNCPTzmz5/f7ADiww8/lGEYoZ4U4RfQb7rpJk2YMEEbN26Uz+fTY489pttvvz1i+08//VRz586V\nYRiyWq26/fbbdfHFF0e0Wbt2raZMmaIdO3Y0q8Zwr776aih8sFqtuu2223TppZdGtAn2Rti5c6e+\n/PJLPfzww5o8eXLax46nvr5ea9eu1fe+9z3dfvvtOumkk/Tdd99p7dq1OuiggzRq1Cjdcccd8ng8\nWrp0qTweT8zXXJL+9a9/hZYbD720dOnSUPhQUlKie+65R0OGDImq5e6779bjjz+umpoa3XjjjXrp\npZcYjgkAAKAdYhJqAAAAoA356KOP9Oabb8owDPXp00dz5syJCh8k6fDDD9dDDz0ku90u0zT16KOP\nqrq6OqLN888/H7oY//vf/z5m+CBJ559/voYPHx66v2HDhrj1GYah4cOH609/+pN69+4tp9Op4cOH\n67TTTovZ9tRTT9X//u//Rn17v6CgQH/84x8lBXpqvPvuuzJNM+5xEzEMQ2PGjNENN9wQ1TOjpKRE\nt956a+j+mjVrora/++675ff7JUlTp06NCh8kafDgwbrnnnsihmdqrkceeSS0PH369KjwQZIOO+yw\n0LwLkrR48eK0jpmMaZqy2WyaP3++Bg0apIKCAvXp00dXXHGFJKm4uFgjR46UJFVVVWnFihUx91NZ\nWamVK1eG5ippHC7MmDEjtDxr1qyo9ZJks9l06623auTIkTJNU1u3btULL7yQoTMFAABANhFAAAAA\nAG3I008/HVoeP358wmF3evXqpdGjR0sKzPUQnOchaNy4cZoyZYrGjh2rESNGJDxu+BA3NTU1CduO\nGzcu4XpJoTDhsssui9umd+/eOuSQQyRJHo9HFRUVSfcb7ziJahowYIDy8vJkmqbKysoi1lVWVmrt\n2rWSAhfZx48fH3c/w4YN05AhQ5odlEjSrl279Mknn8gwDHXp0kU/+9nP4rYdNGiQhg4dqiFDhuhH\nP/qRamtrm33cZAzD0MiRI9WzZ8+4bYLvNSnQayaW1157TR6PR5J0wQUXRKz74IMPQr1iBg4cGLeX\nTVD4cFcvvvhi0nMAAABA20MfVgAAAKANeeedd0LL/fr1S9p+4MCB+uc//ylJev/99yMmWT7//PNT\nOmZlZaV27doVuu/1emO2C377f8CAASntV5JOPvnkhOu7du2qbdu2SQoMvdMcVqs14XOVl5enzp07\na9++fVHHWLlypbxeb6hnR7xhhYLOPfdc/fe//21WnZK0evXq0PLpp5+edFihefPmNftYTZXsdR0x\nYoRKSkpUUVGhZcuWye12R83vkGj4pXfffTe0nMp7+/jjj5fNZlN9fb0++ugj+f3+qHlOAAAA0LYR\nQAAAAABthM/n0zfffBMa4ifWUEDxmKap7du3J2xTWVmpLVu2aOvWrdq6das2b96szz//XJs3b474\nVn+ib/g7HA516dIl5boOOuighOvDL2AHh0FqCsMwVFxcnPRCfvA4jY+xdevW0PIxxxyT9HjpToYc\nPodEKsfLpkMPPTTh+vz8fJ1//vlauHCh3G63li5dqlGjRoXW7969W+vWrZNhGDruuON07LHHRmz/\n5ZdfhpYXLFigBQsWpFyb2+3Wvn37kr6fAAAA0LYQQAAAAABtxP79+0O9DJoz18D+/fujHvN4PFq0\naJGWLFmiTZs2Ra0PHiMvLy9uz4fwtp07d25STQUFBSm3be7QRo2/hd8Ue/bsCS2ncm4lJSXNPpYk\n7du3r0nHy6ZOnTolbTNmzBgtXLhQkvTSSy9FBBAvv/yy/H5/aE6OxsLfn82ZR2P//v0EEAAAAO0M\nAQQAAADQRvh8vtCyYRiaPn16k4acaTxZ9Z49e3Tttdfq888/D+1TkiwWiw455BAdc8wxOumkkzR4\n8GC9/fbbmjNnTtJjWK3WlOtpD8KHZEqlB0Y68z9ICs2P0BYl60UiSf3799eRRx6pLVu2aOXKlaqu\nrlZRUZEk6d///rekwHskPJgICg+4zjvvPPXv379J9cWajB0AAABtGwEEAAAA0EYUFxdLaphrYezY\nsSl9Kz2em2++WZ9//rkMw1C3bt10zTXXaMiQITr66KOjJrduPIF1RxHeo6GysjJp+6qqqrSOF97r\nId19SckDkbq6urSP0djo0aM1c+ZMeTwevf7667r44ov1zTffhCbXPu2009S9e/eo7YLvbykw38TV\nV1+d8doAAADQtjCDFwAAANBG2Gy2iAu3sYZMasztdse8yPzRRx9p7dq1MgxDDodDixcv1rXXXqt+\n/fpFhQ9S5NBA6X7Lvz3p06dPaDmV5zuVNokcdthhoeWvvvoqafsXXnhBv//97zV37lxt2bJFUmQv\nlGQ9Knbv3t28QhMYPXp0qDfN66+/Lqmh94OkmMMvSZHnHj4fRCLl5eXNLRMAAABtAAEEAAAA0Ib8\n4Ac/CC2/8cYbSdvfeeedOvnkkzVs2DA98MADocfXr18fWh42bJh69+6dcD/vvvtuaLkjBRCnnnpq\n6GL66tWrI4bBimXZsmVpHe+UU04JLa9evTrpc/3iiy9qyZIluvfee0NhQvicF+HBUSwff/xxGtXG\n1rt3bw0aNEimaWrNmjVyu9167bXXJAUmKf/Rj34Uc7tBgwaFlpcvX570uf744481ZMgQDRw4UD/9\n6U+bNUk5AAAAWhcBBAAAANCGBL89bpqm/vnPf2rr1q1x227ZskVPP/20DMPQ3r17dcIJJ4TWhc9t\nkOxb5I899pi+++670IX4tjxPQab16tVLp512mkzTVEVFhRYsWBC37ccff6zly5c3awLloKOPPlrH\nH3+8TNNUWVmZnn766bhtN2/erDVr1sgwDHXp0kUDBw6UFBg2yuFwyDRNfffdd/r2229jbu/3+zVv\n3jxJmQ+Vgu/Turo6LVq0SF988YUMw9C5554bd1LwIUOGqGfPnjJNU3v27AnVFs/f//53GYYht9ut\nww47rEnzoQAAAKBt4Dc4AAAAoA0544wzQheaXS6Xxo8fr40bN0a127x5syZOnCiPxyPTNHXyySfr\njDPOCK3v27evpMCF5/feey/mHA8ej0cPPvig7rzzzlBbKTCsU0cyZcoUGYYh0zT197//PWI4oaCN\nGzdq8uTJ8vv9aV/MnzRpkqTA8/2Xv/wlZk+XHTt2aNq0aaFeAuPHj1d+fn5o/eDBg0P7+MMf/hA1\nDFdNTY1+9atfacOGDWkFJvGEBw2zZs0KPX7hhRfG3SYvLy/i3GfOnKlHH3006vl0u9267bbbtGbN\nGpmmKavVqhtuuCHj5wAAAICWxyTUAAAAQIa9+uqrWrt2bcrtS0tLdfHFF4fu33vvvRo7dqzKysq0\nfft2XXrppTr99NPVv39/maapTZs2admyZaGL0yUlJbrrrrsi9nn66afrmGOO0aZNm+T3+1VaWqqh\nQ4fqhBNOkM1m07Zt27R8+XKVl5fLMAzl5+eHej5UVFRk4FloP0455RRdc801mj9/vurr6zV9+nQt\nWLBAp512mmw2mzZs2KAVK1bI5/PJbrfL5XJJUrO/kX/22Wfriiuu0KJFi+RyuTRlyhQNGDBAgwcP\nltPp1ObNm/XGG2/I5XLJMAwNHDhQEyZMiNjH1VdfreXLl8s0Tf33v//V2WefrXPOOUfdunXT1q1b\n9eabb6qqqkq9e/dWjx49IobkyoSioiKdddZZeumll0LPR48ePTRkyJCE240dO1bvvfeeXnzxRfl8\nPv31r3/VokWLNGLECHXt2lXbt2/XW2+9pT179kiSDMPQ9OnTdeyxx2a0fgAAAGQHAQQAAACQQaZp\nyuVyhS7KJmMYhqqrqyMe69mzp5YsWaKbbrpJH3zwgUzT1MqVK7Vy5cqI7QzD0NFHH60ZM2ZETPAr\nBS6Oz5o1SxMmTNCOHTskSatWrdKqVaui9jFo0CDddNNNuuKKK2SapjZs2BD33NqaTNX061//Wj6f\nT0888YRM09T69esjLtobhqHBgwfrzDPP1F/+8hdJijmZd6r+8Ic/qKSkRHPnzpXP54t5PMMwNHLk\nSN11113Ky4v8023IkCH67W9/q7vvvls+n0+7d++OGD7KMAwdc8wxuu+++3T33Xc3u85ERo8erZde\nekmmacowDF1wwQUpbfe3v/1NvXr10rx58+T1erV161Y9/vjjEbUbhiG73a7p06fryiuvbJH6AQAA\n0PIIIAAAAIAMyeRQNwcffLAWLlyoFStW6JVXXtEHH3ygPXv2yOPxqEuXLjr++ON13nnn6Sc/+UnU\nxemgI488Ui+++KIWLFigt956S19//bVcLpccDod69uypfv366fzzz9eIESMkSX369NFXX32lb7/9\nVuvXr9eAAQOizi3VcwxeRE63baJ9ZLqmW265RaNGjdJTTz2ld999V2VlZSooKNCxxx6rSy65RGPG\njNFTTz0Vau90OlM6bjw33nijRo8eraeeekqrV6/Wjh075HK51K1bNw0YMECXXHKJhg8fHnf78ePH\na/jw4VqwYIFWr16tXbt2yW6366ijjtKoUaM0duzYUEiS7Dluznt32LBh6t69u/bs2SPDMBIOv9TY\ntGnTdOmll2rJkiVavXq1vvvuO1VVVamwsFBHHnmkhg4dqrFjx6pnz55NrgsAAABth2G2xa8xAQAA\nAEAb9PDDD4cmR/71r3+ta665prVLAgAAANosJqFO4E9/+pP69u2r559/Pu19ffHFF/qf//kfjRgx\nQieeeKKGDRumG264QW+//XYGKgUAAADQHPX19br//vv18ssv68svv0zaftOmTaHlo446qiVLAwAA\nANo9hmCK480339TChQsz0o1+6dKlmjp1qrxeb2h/e/fu1fLly7V8+XJdddVVuvXWW9M+DgAAAICm\nsdlseuihh1RfX6+ioiKtWbMm7pBWZWVleu211yRJVqtVAwcOzGapAAAAQLtDD4gY3nrrLd10000Z\nmdDu008/1c033yyfz6eTTz5ZTzzxhNasWaOnn35aZ599tiTpiSee0MKFC9M+FgAAAICmGzx4sCSp\npqZGd9xxh7xeb1SbXbt26brrrlNdXV1ovoPi4uJslwoAAAC0K8wBEcY0Tc2aNUsPPvigTNOUaZoy\nDEN33HGHxowZ06x9Xn/99VqxYoWOOOIIPf/883I4HBHrp02bpldffVVdunTR0qVL057IDgAAAEDT\nfPTRRxo3bpx8Pp8kqWfPnjrjjDPUs2dPuVwubdmyRcuXL5fH45EkHXLIIXrhhRdUVFTUmmUDAAAA\nbR49IA54++23deGFF2rOnDkyTVMnnHBC2vv86quvtGLFChmGoYkTJ0aFD5L029/+VhaLRRUVFXr9\n9dfTPiYAAACApunfv7/uu+8+FRcXyzAM7dq1S4sXL9Z9992nhx9+WG+88UZoONVTTz1VixcvJnwA\nAAAAUsAcEAf88pe/lGEYys/P18SJE3XBBReEhkhqrv/85z+SJMMwNHLkyJhtevbsqeOPP14bN27U\n0qVLm93TAgAAAEDznXXWWXr99df1zDPPaMWKFfryyy9VWVkpp9Opgw8+WMcff7zGjBmjIUOGtHap\nAAAAQLtBAHGAxWLR2WefrWnTpumoo47Stm3b0t7nZ599Jknq3bu3SkpK4rbr16+fNmzYoA0bNqR9\nTAAAAADNU1xcrAkTJmjChAmtXQoAAACQEwggDnjllVd0xBFHZHSfwRDj0EMPTdiud+/ekqSdO3fK\n7/fLYmFkLAAAAAAAAABA+8aV7gMyHT5IUnl5uQzDUOfOnRO269Spk6TAJNiVlZUZrwMAAAAAAAAA\ngGwjgGhBdXV1kiS73Z6wXUFBQdQ2AAAAAAAAAAC0ZwQQLYihlAAAAAAAAAAAHRVXyFuQ0+mUlLxX\nQ/j6ZL0lAAAAAAAAAABoDwggWlCnTp1kmqaqq6sTtgvO+2C1WlVcXJyN0gAAAAAAAAAAaFF5rV1A\nLjvyyCP1zjvvaNu2bQnb7dixQ5LUo0ePFqnD6/XJMIwW2Tcki8WQYRgyTVN+v9na5QDIED7bQO7i\n8w3kLj7fQG7isw3kLj7fbZPVmrl+CwQQLei4446TJH333XeqqalRYWFhzHYbNmyQYRjq169fi9RR\nXl7bIvtFQNeuhbJaDfn9pvbtq2ntcgBkCJ9tIHfx+QZyF59vIDfx2QZyF5/vtql7904Z2xdDMLWg\nM844Q5Lk8/m0YsWKmG127typzz77TJI0fPjwrNUGAAAAAAAAAEBLIoBoQYcddpi+//3vyzRN3Xff\nfTHngrjjjjvk9/vVpUsXjR49uhWqBAAAAAAAAAAg8wgg0rRr1y6dd955+vGPf6x77703av0tt9wi\ni8WiLVu26IorrtCqVatUXl6ujRs3qrS0VK+99poMw9CUKVNkt9tb4QwAAAAAAAAAAMg85oBIk9fr\n1ZYtW2QYhnbv3h21/sQTT9Sf//xn/f73v9emTZt07bXXRqw3DEPXXHONxo0bl62SAQAAAAAAAABo\ncQQQCRhGYBb2VNqF3zZ20UUX6cQTT9S8efO0du1a7dmzR06nUyeddJKuvPJK/fCHP8xo3QAAAAAA\nAAAAtDbDNE2ztYtAyyorq2rtEnJa166Fslot8vn82revprXLAZAhfLaB3MXnG8hdfL6B3MRnG8hd\nfL7bpu7dO2VsX8wBAQAAAAAAAAAAMo4AAgAAAAAAAAAAZBwBBAAAAAAAAAAAyDgCCAAAAAAAAAAA\nkHEEEAAAAAAAAAAAIOMIIAAAAAAAAAAAQMYRQAAAAAAAAAAAgIwjgAAAAAAAAAAAABlHAAEAAAAA\nAAAAADKOAAIAAAAAAAAAAGQcAQQAAAAAAAAAAMg4AggAAAAAAAAAAJBxBBAAAAAAAAAAACDjCCAA\nAAAAAAAAAEDGEUAAAAAAAAAAAICMI4AAAAAAAAAAAAAZRwABAAAAAAAAAAAyjgACAAAAAAAAAABk\nHAEEAAAAAAAAAADIOAIIAAAAAAAAAACQcQQQAAAAAAAAAAAg4wggAAAAAAAAAABAxhFAAAAAAAAA\nAACAjCOAAAAAAAAAAAAAGUcAAQAAAAAAAAAAMo4AAgAAAAAAAAAAZBwBBAAAAAAAAAAAyDgCCAAA\nAAAAAAAAkHEEEAAAAAAAAAAAIOMIIAAAAAAAAAAAQMYRQAAAAAAAAAAAgIwjgAAAAAAAAAAAABlH\nAAEAAAAAAAAAADKOAAIAAAAAAAAAAGQcAQQAAAAAAAAAAMg4AggAAAAAAAAAAJBxBBAAAAAAAAAA\nACDjCCAAAAAAAAAAAEDGEUAAAAAAAAAAAICMI4AAAAAAAAAAAAAZRwABAAAAAAAAAAAyjgACAAAA\nAAAAAABkHAEEAAAAAAAAAADIOAIIAAAAAAAAAACQcQQQAAAAAAAAAAAg4wggAAAAAAAAAABAxhFA\nAAAAAAAAAACAjCOAAAAAAAAAAAAAGUcAAQAAAAAAAAAAMo4AAgAAAAAAAAAAZFxeaxcAAAAAAACA\ntsnrldxuqa7OUF1dYNntDizX1RlyuRRaDraLbBNYTrQPt1uy26VOncwDP+HLpnr2lEpKpKIiSbKE\n1nfubKqwULJaW/tZAgDEQwABAAAAAADQhgVDgHgX9QO34YGA0ahN8mCg8b6C7bxeo7VPP4xFUmHU\no4WFgTAiGF4UFcW7HxlshN8vKpIsjBMCABlHAAEAAAAAAJCExxN5Yb6uTnK5jJgX9xNd1I/sCZA4\nIAju3+drSyFA21NTY6imxtCOHentp6jIDPWsKCpqCCei7+tAaBF5v1OnQI8MggwAaEAAAQAAAAAA\n2jzTDPQEaHzhvuGif+JhfhoPFdR4CKB4wUCwHSFA7quuNlRdnV6QYRiRYUWiXhedOulAuBF5v1Mn\nU04nQQaA3EAAAQAAAAAAUhIMAeJ9Uz+1YX4iQ4OmDBXk9xMCoG0zTUNVVVJVVXrvVcOIHiKqYVip\n6Pvxgo3CQsngYwOgFRFAAAAAAADQjphm5HBAiS7qx+8JkCg8iOwJ0HhfhAC5LS/PVEGBZLebstul\nggKpoCCwbLc3rAvcNqxruG1YX1BgyuEI3Abbx9qHzWbK7W64cB/8qawM9Erwem2qrraoosJUWZlX\n1dWBdcF21dVSZaXRxuarSI9pBs6xsjK9c7JYIsOKYO+M1O43hBpOJ0EGgOYhgAAAAAAAoImCIUCi\nngCR91Ob8LfxUEGx9xm4OInclZcXecE/MhCIHRCEX+gvKJAcDjNOeBB/H3a7lNdKV4o6dTLVvbsk\nmVHruna1yWqVfD5T+/a5Y25vmoHPY3gg0RBmKM5y7NAjl4bb8vszF2QkG04q/pwZDZOBE2QAHQ8B\nBAAAAACgXTJNqb6+4QJ+ZWUgFKipkXbvtiTtCdDcoYKC+yIEyG35+cl7AjTcT9wTIDo8iLWPhvCg\ntUKA9swTES8UAAAgAElEQVQwJIcjELz06CHFCjJSYZqBkC8YZARCiYawItD7Itb94DYN93MtyNi/\nX9q/P71zslobwoqiosieFoH78UOO8GDD4SDIANoL/ksDAAAAADRbMARINqlv454AqQwVlKx3QfwQ\nwCKpMNtPBVpAfn7si/rJvsUffjE/Xk+AZAGB1draZ4/WYBiS0yk5naYOPljKRJAR3suisrIh2GgI\nNwJBRrAHRjDICN7PpWHPfD5DFRVSRUV655SXFxlcBAKK8Pvhw07FDzbsdoIMoKURQAAAAABAO2ea\nivkt/uBF+lQu5scbKiiVeQaQ22y25OP5N+4J0PiifvzwIHFPAEIAtFeZDDJqa4MBRaKhpZIPNZVL\nQYbXa6i8XCovz1yQEXtoqchJvcODjfDJwAsKCDKAeAggAAAAACADEoUA4ZP+pjbMT+pDBRECdAw2\nW+OL+YmG+Yk9VFAgPGh6TwCLpbXPHui4DEMqLJQKC9MPMmpqGnpahIcZjefMSHw/t4afy1SQkZ8f\nGUgEg4uGYaZiz5kRHmwEe2QAuYYAAgAAAEBOM02pujow3ENFhaH9+wM/wVAg2VBB8XoCRAcDuXNB\nBrE1TPCb+oS/iXoCpB4eEAIASI9hSEVFgQviPXs2L8SQGoKMZL0uwoeaCg86wtflUpDh8Rjat8/Q\nvn3p7cdmawgyGk/g3fh+omCjoCAz5wVkAgEEAAAAgDbPNKWqKoUChPAwoaJCoceibwPrcmki0I4u\nugdAw4X7oiKLHA5Ddrspw/CGXdxPPFRQdHgQuX9CAAAICA8yevVqfpDh9weGlgqfB6PxJN7Jgo1g\nqJFLQUZ9vaG9ew3t3Zvefmy2yEm7G0/iHZwzo3Gw0XjODJstM+eFjo0AAgAAAEBW+P0NPREahwjl\n5YGwIHaIEFiXS2NXt3eJxuwPv5gfeT/x+P+p9ASw2RKHAF27FspqNeTzmdq3z529JwQA0CQWS+aC\njPAeGbEm8U5laKnq6tz6HaO+3tCePYb27ElvPwUF8efFiDdnRniwEZwzIz8/M+eF9okAAgAAAEDK\n/P7ongiRYQIhQrY0vtAffuE+1kX9VCb8jdcTIHz/NhsTbQIA2gaLRaEL4M2dH0Nq+JJEokm8A70v\nGtbFul9Tk1v/QQaGoEw/yLDboyfxDt7v0cNQcXEgkMrLy084GThBRvtEAAEAAAB0MKmECIEeCdEh\nQmUlIUKQYcS/4B/r2/6JewIkCg9i9wQgBAAAIDMsFqlz58DF8XSCDJ+voUdGcCiphmGlYgcbsZZz\nLcgIzKGVLMiwSEo8C7fDETlpd/gk3g3BRvj8GbHnzMjjinhW8XQDAAAA7ZDfL1VWNq8nQkcKEZxO\nUyUlpoqLw2+l4mJThYVmzIv7qQ4jlJ9PCAAAABpYrQ1BxiGHpBdkhPfIiJ7UO/acGYH7DdvV1ubW\nLyoulyGXy1BZWXr7cTgSDy0VHmzEnj/DPNBjIzPnlet4mgAAAIBW0pQQoXGPhMrK3Jp0MZHCwvgh\nQvjjkW0C65k8EQAAtDdWq0K/y6TTI8PrbTy0VONJvRWaLyN6Do2GYadyNcjYvTu9/TidZljvCkUs\npzpnRqdOgdc7lxFAAAAAAGnw+eKHCIFbRU24TIiQOERoCBMC6xnvFwAAoOny8qSSEqmkJDNBRrxJ\nvBMPLdVw3+XKrd97a2sD4UwmgoxYk3h37qyw+TIa7geHmmoYVipwv60GGQQQAAAA6PCaGyJUVAT+\noOooIUJRUawQIRAUJOuJQIgAAADQPmUqyPB4FDGUVHW1IdO0q6bGovJyv3bu9EQNNRXsoRF+P1eD\njF270ttPYWHsICM4R0bj++GTgQfvFxZmPsgggAAAAEBO8PmUcN6D4JBGtbWBQKG83NDevYWqqAj8\nQdNRECIAAACgNeTnS126SF26NAQZXbsGLnj7fNK+ffUp7ae+PtnQUkajOTSih5qqrg5MjJ1LamoC\nE5jv3JnefoqKTFVVZaYmiQACAAAAbUiqIUKsx5seIhgHftqfYIgQKyiIFS6EhwhMlgcAAID2zGYL\nBBddu6bXI6O+XhHhReNJvKOHk4q9rq6uff5NEU91dWbPhz8/OoD3339HH3zwblr7uPjicerSpWuz\nty8v36dnn12UVg0DB/5Ap5xyalr7eOaZRaqo2Nfs7UtKuuqSS8alVQOvRwNejwBejwZt6fUwjIb/\ncE2zab/Q8Ho04PMR0NFeD5/PkNttl8sV/dOlSx85nYfHDRGqqnLrl/dEior86tIleg6EVEOERK+H\n3y/t2xf4SYTPRwP+vQrIlddjz549+sc/5qdVA69HAz4fAbweDbL9esT63ZzXowGfjwa8HgG8Hg0S\nvR42m9Stm6lu3aREQUay18Prtaquzia3u0B1dQVyu20HbgPLFkuJjjhiQGjOjMhhphru51qQEUQA\n0QF4vV7V1dWltQ/T9Ke9fbo1eL3etLaXpPr6+rTqqK9PrStYIrweDXg9Grbn9QjI1dcj76P1cjww\nW7YVy2RUp9aP8Rc+X5ODjwiGobxfTWv+9pJ+5PfrTJ8v4jHTaNovRHm33x7xB2NykW27ydSvPJ4m\nHbMxi9Uqq8Xa5NrDTfB60no9DMOivP+Z3uztJelMv08jGr0eTZX/5z/LMCyxV8Z4fkwz8qeT31Sp\n13dgndFwa0qmwm5jiPd4JrTkvlPZv2GYoduIZZmSEVxvyjAi2xZYC2RUG1KNIW1vel1d/KZurHMn\nrz/Bez8vL1/5+en9SXBVXZ1Mf/P/7TUsFtl////irU1pHyO9Hg1N498K0zDkuOdeGcEBbwMvVsPn\novGyjIbSDEOmYajY79cvqypDz3f4855sOXjrLCyUs7BT2DEVo4ZG98PWm4ahC8p2yXPg/6FUjxu+\nnJ9vU+dnnok+bqhtjOelUQ0nle/VIfv2NrsGSeqx7n0V2B1Jzl2N7hsy7PmSxaKi2lr98JNPApcS\nDKPhkkJwOXj8GMvBtr0++FDO116NPvd474tYz8WH78vlqk2phljrHc5C2SsqY5x7avdNw1DPr79U\n3683p37cGDUWOjrJ1qk4+XEPPE2N1zmqq3Tohg1Jn/NENXay5CvP4094nESvjylDnb/+Sqrc3+z3\nhaPGJcvXXzXpfRDxesiQpaxM1r17kz7nCWusqZYK7CkfN+q54O+PkIz//RH8fTH8NtZj4evcLvmq\nq0OPGY32FX4/3jqjvFzGgX93Q2+aBMc2FL3OtnuXbBXlgX024djBdY7qWlk3b2qoIdl5x1jn+OIL\nlWzZ0uRjh68reH+d8joXx6wh1nk3rstRtV+9P/20WccO3u/qqpetbG/EuqTvBUU+dsTaNepWXdXs\n18NZWKQCjz+yTbwa4tTVe8tmebd81eRjh68rKa+Sw1mY4DimDIct8F+s35Szti6yLletBn/0QfTx\nmvCc9Hp/vQpffjnl845Yd+B1GfzZRtW5Xc1+PWwFdh3d6ZjAY3ZTskvqFl2D32vK4zHl8Uje+sCc\nGR6PKa/HUEV5laqqauX3WeT3WeTzWeX3G/IfuDV9Fvn8Fpk+i0wZCvzPF/beb3Sb6DG/LJKeV6YQ\nQAAA0BJMU/krlsk5e6Zs/1nW5M0z8h90mhfurQd+WrMGQ5ItQzUYSZolknYNkpTCheJELJLSHn4/\nzT+wEYfZ6DZVLldah7Wobfwy78zEToIXXpqp4MBPa9YgSd3S3kP6DsnETj7dmNbmvQ/8pGX9+rQ2\nL5Q0ON0aMmBoJnbyzNNpbX7ygZ+0LFmS1ubFkn6Wbg0ZcEUmdvKn29Pa/OwDP2n5y1/S2ry7pD8c\nWG5uaGq1WmWx5sUIOhS23GhdWIBpGoYmuF3yx/mChxH2uNGoTfC+xbCo4P/+90Bx4Rfy1PBY1Doz\nYh/n+rw6p9EXPFI5dviycdttMc8hVd0lxYvhs2lCJnby5z+mtfkZB37SMm9eWpuXSLoq3Roy4MeZ\n2MmTC9La/KQDP2l5/fWUm1oU+P87XKGkH6ZbQwYMzMROVq/KxF7apbbwNwsAADnD8PnUa8Vyldzy\nG+V//GFrlwMAAABECeUEjb/5m0VFmdhJTXqbc1EMAFoe/9Z2AHl5eSooSO87YXGHa2jC9unWkJeB\nGRNtNltaddhs6X8HltejAa9Hw/a8HgFt6fVo6hwQefX16r9unU5duVIl5eVp1QAAAAAAAJALDDOt\nAabRHpSVpTbeOJqna9dCWa0W+Xx+7duX5tcvALQZqX62jb175Zg/V455D8mSbLZXSf6DDpJpbeH8\nP0v/tTfukt4isvZrSvLjhOZC8Ev+0LIRtqy4y6YaxtZsadk4TqJjhI+4EPyxBJctsdaZoccjtOBr\nbxiGDB0YGtifQ+/jXPpMZuE4Df+GmdHDc8S6H7aclX//AAAAgNaSwd936QEBAEAzWLZ+I+cDs2Rf\n+ISMFMZxrzvnPLlKp8kzeEiMK63IFo9HqqgwtH9/8NZQRUXkT+AxhdYFb2trO8brZhimioul4mJT\nJSVmjFuppCT2us6dJUt6nZCyIhgw+vnyADKhieFFVJihVLdV3H1FTaqZSk1h9yNriH+cRPsxmhzk\nKLqGJjxvURNYHrhfVFggq8WQz+dXdZUr9fNRo3Ap1edRiro1krWNuS7suYi7bZJ9xTuHVM5HkceJ\nWUOS1yDWutjPhSLbJvgMxH8u4tTf+LlK9HrE3TaFGsLPIclnOOF7Ku62KdSR7N+OGOdjNK6/iZ/b\niBoSPm+xX6+kwW/EfBGKmkPCkGQaRmCzqPklwm9jPRbWXpHrzIT7SrJOYcc88JjZ3H3FqS/uPo3o\nY6eyr8bHNpPVF3df8Z6TJjynSnLsuOev6O1SONeISeFTeX1i1qe42yV8LlM818TPaaNjq3n7ivmc\nJquvqeefqL5GjxUWFchischvmqqp9USfd8Q+m3Cuqbw/U33fhNalcP5pvtYR+2ziezCV48TeZ6PH\nLBZ1VeYQQAAA0AR5H38ox/0zVfDCczIaTVjXmJmXp7pLxqp20o3yHd8vSxXmvvp6JQwKCBGkjhAi\nAG1GxB+xTWcmb5KVfeSMroWS1SL5/KonYARyBl8eAHKX88D/3abPLzef75xEAAEAQDKmqfy3V8g5\ne4Zsy99K2txfWCT3z8fLdf0k+Q85tOXra4dSCRFi9VTYv7/jhgjRgUH8EKFTJ0IEAAAAAEDrI4AA\nACAer1fGkiUq+eudyv9ofdLm/u49VHvdRLmvniCzpEsWCmxddXWJQ4SG244bIlgsze+JQIgAAAAA\nAGjvCCAAAGistlbGPx+X7r1Hlq++UrJrwN7v9ZFr0o1yjx0n2e1ZKTFTUg0RAj+R610uQoSGngmR\nPRWCy0VFhAgAAAAAgI6LAAIAgAOMfXvl+McjcjzyoCx79yZt7znl+6otvUn1Px4lWa1ZqDA2t1uN\n5j+I7nEQL2ToSCFCeI+D2GECIQIAAAAAAJlEAAEA6PAs326V48HZcjz5uIza2qTt6350jlyl0+QZ\nMjStiUfDNTVECJ9s2e3uGCGC1RoIBZKFCI0DhGCIkKGXCgAAAAAApIgAAgDQYVk/+VjO+2eq4Pln\nZPh8CduaeXmqu+hS1U6eKl+/E0KP19dL1dVSdbWhmhpD1dU6cNuwHPgJtInXE6EjhQhN6YlAiAAA\nAAAAQPtFAAEA6DBMU6qtMaVlb6vk4RkqWfNm0m3ceYV65dBfaGGPG/X1V0eo5obIsMHj6XhXxJsb\nInTpYqqwkBABAAAAAICOggACANBm+XxSTU10j4JYvQwCoUBDj4OGXgmBW1e1X+fWPKvp5l36gdYl\nPfYu9dB9ulFzvJNUsaWLtKXlzzebwkOELl3ihQjRIUNJCSECAAAAAABIDQEEACBjEg1HFAwCwocj\nCt42Xh/cLhMTJNvl0ng9qpv1dx2tzUnbb9LRulvT9biukluOtI/fkvLyUumJQIgAAAAAAABaBwEE\nAHRQpim5XIo7V0FkKBA7KGgcGrSl4Yi6aJ8maY5u1H3qobKk7d/VIP1Nv9Fzukh+WbNQYUC8EKHx\nRMqxQgZCBAAAAAAA0JYRQABAO9F4OKKGUCDWY4mHIwqGB35/7l29PkxbdZPu1S/1sIpUk7T9KzpP\nf9NvtEIjJKX2fBhG4OJ/UVHDbfhyYWFgubDQPLBOoceKiwkRAAAAAABAx0AAAQAtJDgcUby5Cpoy\nHFFtraHaWq5SJ3KSPtL/6C6N0yLlyZewrVdWvdXjMj1/zK+0p3d/HVVo6qSi+lBQUFQkHXywTcXF\nFjmdfvn9rlCAUFRkyukkNAAAAAAAAEiGAAIAlHw4okThQHiQEB42tKXhiNobh8OMuOAfDAWCt6HH\nCk0dv/s/On3V33XkxteT7td0OuX62dVyXT9ZAw87XAMlSe6Ybbt2tclqDfQ82bfPn9HzAwAAAAAA\n6AgIIAC0S/GGI0o2qXHkxMi5PxxRNsQajqhxUBBrOKLI4YsaHnM6pbxk/zv5fLK9/G85Z9+r/A/e\nT1qj/6CD5PrFDXKNv1Zm126ZOXEAAAAAAAAkRAABICsaD0eUfFLj2L0MGI4ofXl5jXoRhOYniAwC\nwnscRM9l0ErDEbndsv9zoRxz7lPe118lbe474kjVTrpR7suvlByOLBQIAAAAAACAIAIIAFHChyNq\n6lwFsYYjqqmR6usJDJor5eGI4gQJjSdJLiho7TNqOqOiXI5H58kx9wFZ9pQlbe85eaBcpVNV95PR\nktWahQoBAAAAAADQGAEEkAN8Pqm2NlYo0LThiMIDA4Yjap5WGY4oh1m2fSfHg/fL8cSjMmprkrav\n/+FZqi2dJs+wM5glGgAAAAAAoJV14MtaQOtpynBEsYYgCp/omOGI0tOuhyPKYdZPN8p5/0wVPLtE\nhtebsK1ptapu9MWqnTxVvpP6Z6lCAAAAAAAAJEMAASSRbDgiKTAZcmWlVFZmixkUMBxR5mRqOKLg\nbXscjihnmaby/7tKjtkzVPDm68mbO51yXXmVXNdPlv/wI7JQIAAAAAAAAJqCAAI5J3w4olTmKsjc\ncEQWSVzNDsdwREiJzyfbKy/Jef8M5b+3Lmlzf7ducl17vVwTfimza7csFAgAAAAAAIDm4FIeWl19\nvZo4qXHkEESNexkwHFHzMRwRssrtln3JU3LMuU95m79M2tx3+JGqnTRF7suvlJzOLBQIAAAAAACA\ndBBAoEmSDUcUa6LjxkFB48mSGY6o+RiOCO2Rsb9C9kfnyTn3AVnKdidt7znpZLmmTFPdT0bTBQYA\nAAAAAKAd4UpOB1BVFTscSBQUhIcKzRuOCI1lYjiihmGJGI4I7Y9l+zY5Hpoj++P/kKWmOmn7+hE/\nVG3pNHnOGElXGgAAAAAAgHaIy5cdQJ8+nVq7hHYp1eGIunfPV+fOFhUW+iXVRQUMwWWHQ7JYWvus\ngOyzfvapnPfPVMEzi2V4vQnbmhaL6sZcLNfkqfKedHKWKgQAAAAAAEBLIIBAzmjOcEThPQqaOxxR\n1675sloDk1/v25f44irQYZim8tf+V47ZM1Tw+qvJmzsccl/xc9XeUCr/EUe2fH0AAAAAAABocQQQ\naBVNHY4oUVDAcERAG+L3y/bqy3LOnqH8de8kb961q1wTrpPr2utlduuWhQIBAAAAAACQLVyyRUpS\nHY6oIRSINX8BwxEBOauuTvYlT8kx5z7lfbkpaXPf4UeodmKp3Jf/TCoszEKBAAAAAAAAyDYCiA6g\nXz9fo1AgeqLjTA1HBKBjMSr3y/7ofDnmzpF1966k7T0n9perdKrqLryIbksAAAAAAAA5jqs/HcDy\n5bWtXQKAHGPZsV2OuQ/I/th8WaqrkravHz5StVOmyTPih5JhZKFCAAAAAAAAtDYCCABAyqyffybH\nnPtkf/qfMjyehG1Ni0V1F46Ra/JUeU8emKUKAQAAAAAA0FYQQAAAkspbu0bO2feq4LVXkrY17Xa5\nx/1MtROnyH/kUVmoDgAAAAAAAG0RAQQAIDa/X7bXXpFz9gzlv7s2efMuXeSacJ1c114v86CDslAg\nAAAAAAAA2jICCABApLo62Z9ZLMf9M5W36YukzX2HHibXxFK5rrhKKizMQoEAAAAAAABoDwggAACS\nJKNyv+yP/UOOuXNk3bUzaXvvCSeptnSq6i68SMrPz0KFAAAAAAAAaE8IIACgg7Ps3CHH3Adkf2y+\nLFWVSdvXDx+h2slT5fnhWZJhZKFCAAAAAAAAtEcEEADQQVk3fSHHnPtkX/KUjPr6hG1Ni0V1Pxkt\nV+lUeQeckqUKAQAAAAAA0J4RQABAB5P37lo5Z81QwasvJW1r2u1yX36lam8olf97fbJQHQAAAAAA\nAHIFAQQAdAR+v2xvvCbn7BnKX/vf5M1LSuSa8Eu5rr1BZvfuWSgQAAAAAAAAuYYAAgByWX29Cp5d\nIuf9M5X3+WdJm/sOOVSuiaVyXXGVVFSUhQIBAAAAAACQqwggACAHGVWVsj/+qBxz58i6Y3vS9t7j\nT1Bt6VTVjblEys/PQoUAAAAAAADIdQQQAJBDLLt2yvHwg7I/Ok+Wyv1J29cPHS5X6VTVn3m2ZBhZ\nqBAAAAAAAAAdBQEEAOQA65eb5Jhzn+yLF8mor0/Y1jQM1Y+6ULWlU+U9ZVCWKgQAAAAAAEBHQwAB\nAO1Y3rp35Jw9U7ZX/i3DNBO2NQsK5L7sSrkmlcr3vaOzVCEAAAAAAAA6KgIIAGhv/H7Z3nxNjtkz\nZVuzOnnz4hK5JvxCrmtvkNmjRxYKBAAAAAAAAAggAKD9qK9XwbNL5Jxzn/I++zRpc1/vQ+S6YbLc\nP7taZlGnLBQIAAAAAAAANCCAAIA2zqiukv2Jx+R46H5Zt29L2t57fD/VTp6quosulfLzs1AhAAAA\nAAAAEI0AAgDaKGPXLjkfeVD2fzwiS+X+pO3rTx8mV+lU1Z91jmQYWagQAAAAAAAAiI8AAgDaGOvm\nTXLMmS374oUy6uoStjUNQ/XnX6Da0qnyfv8HWaoQAAAAAAAASI4AAgDaiLz318k5a4ZsL/9Lhmkm\nbGvabHJfdoVck6bI1+eYLFUIAAAAAAAApI4AAgBak2nKtvR1OWbPlG31yqTN/Z2L5b7mF6r9xQ0y\nDz44CwUCAAAAAAAAzUMAAQCtweNRwXNPy3n/TOV9ujFpc1+v3nJdP1nuq8bLLOqUhQIBAAAAAACA\n9BBAAEA2VVfL8eRjcjx4v6zbvkva3HtcX9VOnqq6i38q2WxZKBAAAAAAAADIDAIIAMgCY/duOeY9\nKMc/HpGloiJp+/rTTperdKrqf3SuZLFkoUIAAAAAAAAgswggAKAFWb7aLOecWbL/80kZdXUJ25qG\nofrzRqm2dKq8PxicpQoBAAAAAACAlkEAAQAtIO+D9+ScPVO2f78gwzQTtjVtNrnHjpNr4hT5jjk2\nSxUCAAAAAAAALYsAAgAyxTSVv+xNOWfNkG3V20mb+zt1lnv8tXJdN1H+g3tmoUAAAAAAAAAgewgg\nACBdHo8Knn9GztkzlffphqTNfT17yXX9ZLmvGi+zU+csFAgAAAAAAABkHwEEADRXdbUcCx+X48H7\nZf3u26TNvccep9rJU1V3yVjJZstCgQAAAAAAAEDrIYAAgCYyysrkmPeQHPPnylJRkbS959TTVDvl\nJtWffa5ksWShQgAAAAAAAKD1EUAAQIosX38l5wOzZH/qSRlud9L2deeNUu3kqfIOPi0L1QEAAAAA\nAABtCwEEACSR9+EHcsyeqYJ/PS/D70/Y1szPl/unl8s16Ub5jj0uSxUCAAAAAAAAbQ8BBADEYprK\nX/6WnLNnyPb2iqTN/Z06y331BLmumyh/z15ZKBAAAAAAAABo2wggACCc16uCF56Vc/ZM5W34OGlz\n38E95bpuktxXXyOzc3EWCgQAAAAAAADaBwIIAJCkmhrZFz0h5wOzZf12a9Lm3qOPkWvyVLkvvUwq\nKMhCgQAAAAAAAED7QgABoEMz9uyRY95DcsyfK0t5edL2nkGnqnbKTao/98eSxZKFCgEAAAAAAID2\niQACQIdk2fK1nA/Mkn3RAhlud9L2def+WLWTp8l72pAsVAcAAAAAAAC0fwQQADqUvI/WyzF7hgpe\nfF6G35+wrZmfL/ell8k16Ub5juubpQoBAAAAAACA3EAAASD3mabyVyyTc/ZM2f6zLGlzf1Enua+6\nRq7rJ8nfq3cWCgQAAAAAAAByDwEEgNzl9argX8/LMXum8j/+MGlzX4+D5bpuktxXXyOzuCQLBQIA\nAAAAAAC5iwACQO6prZV90RNyPjBb1q3fJG3u7XO0XJOnyn3pZZLdnoUCAQAAAAAAgNxHAAEgZxh7\n98oxf64c8x6SZd++pO093x+k2tKbVP/jUZLFkoUKAQAAAAAAgI6DAAJAu2fZ+o2cD8ySfeETMlyu\npO3rzjlPrtJp8gweIhlGFioEAAAAAAAAOh4CCADtVt7HH8px/0wVvPCcDJ8vYVszL091l4xV7aQb\n5Tu+X5YqBAAAAAAAADouAggA7YtpKv/tFXLOniHb8reSNvcXFsn98/FyXT9J/kMObfn6AAAAAAAA\nAEgigADQXni9Kvj3C3LMnqn8j9Ynbe7v3kO1102U++oJMku6ZKFAAAAAAAAAAOEIIAC0bbW1sj/1\npJwPzJL1my1Jm3u/10euSTfKPXacZLe3fH0AAAAAAAAAYiKAANAmGfv2yjH/YTnmPSTL3r1J23tO\n+b5qS29S/Y9HSVZrFioEAAAAAAAAkAgBBIA2xbL1Gzkeul+OJx+XUVubtH3dj86Rq3SaPEOGSoaR\nhQoBAAAAAAAApIIAAkCbYP3kYzlnz1DBC8/K+P/s3XuYl3WdP/7nPQPDzCCKKJR41lLBU4mumuIp\na7NM1NwMLFHJVEDQTlr9bPe73w6/tt3E8GweUTO1VstMLWqxNE+VVip5KPOQcvYAMwPMzP39w5XN\nBRmUez4Dw+NxXVzCfF73+/O8ua73Pzy973dHx0pnyz59svjIf0rL+EnpGL5jjRICAAAAAG+GAgLo\nOXt5DPMAACAASURBVGWZvr+6M83nTknDL6Z3Pd7cP62fOC6tJ41P52ab1yAgAAAAAPBWKSD+zmOP\nPZZLLrkk9913X+bNm5eBAwdmp512yjHHHJORI0e+5XV//etf55prrsmDDz6YF198Mf3798+wYcNy\n+OGHZ9SoUSm8NoZ1TUdHGn78wzSfOyV9H/xdl+OdGw9O64knp/X4T6YcuGENAgIAAAAAq6soy7Ls\n6RBrgunTp2fy5Mlpb29/XSHw2l/Psccemy9+8Ytvet1vfOMbufzyy5NkuaKhLMvss88+ueCCC9LQ\n0LAa6VduzpxXum1tkkGD+qe+vi4dHZ2ZP39RT8dZs7W2pvG6a9J8wdTUP/WXLsfbt94mreMnpe2j\no5OmphoEhP9hb0PvZX9D72V/Q+9kb0PvZX+vmQYPHlDZWnWVrbQWe/TRR/OZz3wmHR0d2XXXXTNt\n2rTcc889ufHGG/O+970vSTJt2rRce+21b2rdG264IZdffnmKosi73/3uXHHFFbnrrrvy/e9/P4ce\nemiKosjdd9+df/3Xf+2O24I1RrFgfpq/9W/ZaMSOGXDGp7ssH5a+69156dKrsuDu36Rt7AnKBwAA\nAABYC3kCIslJJ52UGTNmZMstt8xNN92Upv/1j52nnXZabrvttmy44YaZPn16mpubV2nd97///Xnm\nmWfyzne+MzfeeONyTzl89rOfzS233JK6urr813/9V4YMGVLZPf09T0B0L03tG6t79pk0XXRemqZd\nmaKl67+bJQcdnJZTT8/S9+ybeDUZPczeht7L/obey/6G3sneht7L/l4zeQKiQn/+858zY8aMFEWR\nU045ZbnyIUnOPPPM1NXV5cUXX8wdd9yxSuu+9NJLefrpp5Mko0aNWuErlkaPHp3k1Vcx/f73v1+N\nu4A1S/3Df8yA8Sdm0B67pPmi81daPpT19Wk76ujM/8Xdeem6H2TpPiOVDwAAAADQC6zzBcSdd96Z\n5NXzGQ444IAVzrz97W/PsGHDkrx6VsSqqKv7n7/a9vb2Fc707dt32e/r6+tXaV1YY5Vl+t71y6w/\n+iMZdOB70njj91J0dLzxeHNzWj51Subf91BeOf+SdOy4Uw3DAgAAAADdbZ0vIGbOnJkkGTp0aAYO\nHPiGc8OHD09Zlnn44YdXad0BAwZkyy23TFmWueWWW7J06dLlZm688cYkrxYRO++881tID2uAjo40\n/OjmDPzAgRl4xIfSb/pPVzreufHGWXTm/5d5v304i77yjXRuvkWNggIAAAAAtbTOFxDPPfdckmSz\nzTZb6dzQoUOTJC+88EI6OztXae3Pfvazqa+vzxNPPJHjjz8+9957b+bPn5+ZM2fmrLPOyvXXX5+i\nKDJ+/PhsvPHGq3cjUGutrWm88rJs+J4R2WDcJ9L3d79d6XjHllvllW98K/N+83BaPv35lIM2qlFQ\nAAAAAKAn9OnpAD1twYIFKYoi66+//krnBgx49eCNsizz8ssvr/Rpide8733vy9SpU/ONb3wjDzzw\nQMaOHfu6z4cOHZrTTjsthx122Fu/Aaix4sUFabr8O2m65MLUzZ3T5fzSXd+d1omTs/jQUYlXjQEA\nAADAOmOdLyAWL16cJGlsbFzpXL9+/Za7ZlUsXLgw/fv3T7GCQ3Xnzp2b3/72t9l3330zaNCgVV4T\nekLdc8+m6cLz0jTtipUeKv2aJQe+Ny0TT8vSffdzqDQAAAAArIPW+QLi7w+LrtpXvvKVXH311SmK\nImPGjMnHP/7xbL755lmwYEHuuOOOTJkyJdddd10eeOCBXHXVVUoI1kj1jz6S5vPOSb8f3JDiDQ5U\nf01ZX5/Fo45My4TJ6dh5lxolBAAAAADWROt8AdHc3Jyk66ca/v7zrp6WSJK77757Wfnw2c9+NuPG\njVv22eDBg3PMMcdkxIgRGT16dJ588sl861vfyle+8pW3eBcrt+GGzSt8AoNq1NUVy/47aFD/Hk5T\nkbJM7rwzdf/+zRQ/+UnX483NKceNSzn5tPTdaqtsUIOI0N165d4Gktjf0JvZ39A72dvQe9nfvd86\nX0AMGDAgZVlm4cKFK517+eWXkyT19fXZYIOu/3n1hhtuSJJssskmOeGEE1Y4s8MOO+RjH/tYLr/8\n8tx0000566yzXveqp6r06eO9+7VQFEXq69fyoqejI7n55uTf/i25996u5zfeODn11BQTJqTYyKHS\n9E69Ym8DK2R/Q+9lf0PvZG9D72V/917rfAGx1VZb5b777stzzz230rnnn38+STJkyJBVWvepp55K\nURTZddddV/r0wZ577pnLL788HR0defrpp/POd75z1cOvovb2Dk9AdKO6uiJFUaQsy3R2lj0d561p\na0tx9bQU3/pWisce63K83HrrlJ/+TMqxY5P/foooHZ3dHBJqq1fsbWCF7G/ovexv6J3sbei97O81\nU319dccWrPMFxPbbb58kefbZZ7No0aL077/iR30efvjhFEWR4cOHr9K6S5cuTZIsWbJklbO8mdk3\nY8GClm5Zl1cNGtQ/9fVFOjvLzJ/f9eHMa5LipRfTeMWlab74gtTNmd3l/NKdd03rqadl8aGjkj59\nkrYyaVu77hlW1dq8t4GVs7+h97K/oXeyt6H3sr/XTIMHD6hsrXW+gNhvv/2SJB0dHZkxY0Y++MEP\nLjfzwgsvZObMmUmSkSNHrtK6W2+9dZ544on85je/ydKlS9O3b98Vzj3wwANJXn2105ZbbvlWbgHe\ntLq/PZemi85P41WXp27Ryl8/liRL9j8wLRNPy9L9Dkg8TQMAAAAArILqnqVYS22++eYZMWJEyrLM\nt7/97RWeBfH1r389nZ2d2XDDDTNq1KhVWve1IuOll17K2WefvcKZJ554Itdee22KosgBBxyQ9dZb\n763fCKyC+pmPZsCpJ2fQ7jun+YKpKy0fyrq6tB15VBZM/2VeuuHmLN3/QOUDAAAAALDK1vkCIkm+\n8IUvpK6uLk899VTGjBmTu+66KwsWLMgjjzySiRMn5vbbb09RFDn11FPT2Ni47LpZs2blAx/4QA45\n5JDlSoZDDjkke+21V8qyzGWXXZZJkyblgQceyIIFC/Lcc89l2rRpOeaYY9LS0pIBAwbkc5/7XK1v\nm3VFWabvPXdn/Y9/NIP22zON37s2RXv7G483NaV13Kcy/94H88qFl6V9511rGBYAAAAA6C3W+Vcw\nJclOO+2Ur371qznrrLPy+OOPZ9y4ca/7vCiKHH/88Rk9evTrft7e3r7ssOnZs5d/f/7UqVNz2mmn\n5e67784dd9yRO+64Y7l1Bw8enKlTp3r9EtXr7EzDbbem+dwp6fvAfV2PDxqU1hM+ldZxJ6XcaKMa\nBAQAAAAAejMFxH874ogjstNOO+XSSy/Nvffem7lz56a5uTk777xzjjnmmBx44IErvK7471fSFCt4\nNc2AAQNy6aWX5o477shNN92UP/zhD3nxxRfT1NSUrbbaKu9973szZsyYDBhQ3aEekMWL03jDdWk6\n/9vp88TjXY53bLFlWk6ZmLaPfTx5g0PYAQAAAADerKIsy7KnQ9C95sx5pacj9GqDBvVPfX1dOjo6\nM3/+oh7LUbz0YhqvvDxNF5+f+tmzupxfutMuaZ04OYsPOyLpo4uE/21N2dtA9exv6L3sb+id7G3o\nvezvNdPgwdX9D/P+1RHWcnXP/y1NF52fxqsuT93CrsumJSMPSMuppzlUGgAAAADoVgoIWEvV/2lm\nms7/dhpv/F6KpUtXOlvW1WXxYYendcLktO/67holBAAAAADWZQoIWMv0ufeeNJ97dvrd/pMuZ8vG\nxrSN+URaTp6Yzq22rkE6AAAAAIBXKSBgbdDZmYbbf5Lmc6ek7/33dj2+4YZpPeFTaR13UsqNN65B\nQAAAAACA11NAwJps8eI0fv/6NJ13Tvo8/liX4x2bbZ7WUyamdcyxSf/+NQgIAAAAALBiCghYAxUv\nv5TGKy9P08Xnp37WC13Ot++4c1omTs7iw45I+vatQUIAAAAAgJVTQMAapO6F59N08QVpvPKy1L3y\ncpfzS0bun5YJk7P0wPcmRVGDhAAAAAAAq0YBAWuA+scfS9P5307jDdelWLJkpbNlXV0WHzoqrRMn\np/1du9UoIQAAAADAm6OAgB7U5/570zx1Svrd9uMuZ8vGxrR97Ji0nDwxndtsW4N0AAAAAABvnQIC\naq2zMw0/vT3N505J33t/3fX4wIFpPeHEtI47OeXgwTUICAAAAACw+hQQUCtLlqTfD25I83nnpM+f\nZnY53rHpZmk9ZWJaxxybrLdeDQICAAAAAFRHAQHdrHjl5TRedUWaLjov9S883+V8+7Ad0zJxchYf\n/pGkb98aJAQAAAAAqJ4CArpJ3awX0nTxBWm84tLUvfJyl/NL9hmZllNPy9IDD06KogYJAQAAAAC6\njwICKlb/xONpOv/babz+uymWLFnpbFkUWXLoqLRMmJT23XavUUIAAAAAgO6ngICq3HNP1v/a/5+G\nn9ySoixXOlr265e2o49J6/iJ6djmHTUKCAAAAABQOwoIWB2dnckttyT/8e+p/+UvU9/V+AYD03rC\nJ9M67uSUQ4bUJCIAAAAAQE9QQMBbsWRJ+v3ghjSf/+3Uz3y0y/GOoZum9eQJafv42JTrDahBQAAA\nAACAnqWAgDehWPhKGqddmaaLzkv9357rcr592PC0TJicxUcclfTtW4OEAAAAAABrBgUErIJi1qw0\nf+fCNF7+ndS9/FKX80ves29aJ07Okve+PymKGiQEAAAAAFizKCBgJeqffDxN55+bxuuvTbF48Upn\ny6LIkg9+OC0TJ6d9xB41SggAAAAAsGZSQMAK9PntA2meOiUNt/4oRVmudLZsaEgxdmw6T/90Xt54\n0xolBAAAAABYsykg4DVlmYbpd6Tp3HPScPevuhzvXH+DtB3/yfT73KdTv+nQpKMzmb+oBkEBAAAA\nANZ8CghYujT9/vPGNJ93Tvo8+kiX4x2bDE3rSRPSduxxKdcbkH6D+tcgJAAAAADA2kUBwTqrWPhK\nGq++Mk0XnZ/6557tcr59+x3SMmFyFh/5T0lDQw0SAgAAAACsvRQQrHOK2bPTdOmFabrsO6l76cUu\n55fs9Z60TpycJQf/Y1JXV4OEAAAAAABrPwUE64y6Pz+Z5vOnpvF716RYvHils2VRZMkhh6ZlwqS0\n77FnjRICAAAAAPQeCgh6vT6/+02azz0nDbfcnKIsVzpbNjSk7aOj0zp+Ujre8c4aJQQAAAAA6H0U\nEPROZZm+v/hZmqdOScNdv+xyvHPA+mk7blxaP3VKOt/29hoEBAAAAADo3RQQ9C5Ll6bfTd9P87nn\npM+jD3c53vH2TdJ60oS0HXtcygHr1yAgAAAAAMC6QQFB77BwYZquvSpNF56X+mef6XK8fbvt0zJh\nchZ/5KNJQ0MNAgIAAAAArFsUEKzVijlz0nTpRWm67OLUvfhil/NL/2GvtJx6epa87x+TuroaJAQA\nAAAAWDcpIFgr1f3lz2m+YGoar7smRVtbl/OLP/ChtEyYnPY996pBOgAAAAAAFBCsVfo89Ls0nXtO\n+v3ophSdnSudLfv2Tds/fSyt4yelY7vta5QQAAAAAIBEAcHaoCzT979+nuZzp6ThlzO6HO8csH7a\nxp6Q1k+dks63b1KDgAAAAAAA/G8KCNZc7e3pd/MP0nzuOenz8B+6HO9429vT+qnxaRt7fMr1N6hB\nQAAAAAAA3ogCgjXPokVpuvaqNF14XuqfebrL8fZ3vDOtEyan7aijk379ahAQAAAAAICuKCBYYxRz\n56bp0ovSdNnFqVuwoMv5pbv/Q1pOPT1L/vGQpK6uBgkBAAAAAFhVCgh6XN1Tf0nzBVPT+N2rU7S1\ndTm/+B8PScvE09O+5141SAcAAAAAwFuhgKDH9Pn9g2k6d0r6/fCmFJ2dK50t+/ZN21FHp3X8pHRs\nv0ONEgIAAAAA8FYpIKitskzfGb9I87nnpOHOX3Q53rnegLQde3xaTxqfzk2G1iAgAAAAAABVUEBQ\nG+3t6fejm9J07jnp+4eHuhzvGPK2tH5qfNrGHp9yg4E1CAgAAAAAQJUUEHSvlpY0fndami84N/VP\n/7XL8fZt35HWCZPTdtTRSWNjDQICAAAAANAdFBB0i2LevDRddnGaLr0odfPndzm/dMTuaZl4epYc\n8qGkrq4GCQEAAAAA6E4KCCpV9/Rf03zB1DReOy1Fa2uX84vf/4G0TjwtS/fcOymKGiQEAAAAAKAW\nFBBUos8fHkrTeeek383/maKjY6WzZZ8+WfyRj6Zl/KR0DBteo4QAAAAAANSSAoK3rizT95cz0jz1\n7DTM+EWX453910vbJ45L60nj07npZjUICAAAAABAT1FA8Oa1t6ffLTen6dxz0vf3D3Y53jl4SFo+\ndUraxp6QcuCGNQgIAAAAAEBPU0Cw6lpa0njdNWm+YGrq//pUl+Pt22yb1vGT0vbR0UljY/fnAwAA\nAABgjaGAoEvF/HlpuuySNF16UermzetyfuluI9Iy8fQsOeRDSX19DRICAAAAALCmUUDwhuqe/mua\nLjovTddclaKlpcv5xQe/P62nnp6le70nKYoaJAQAAAAAYE2lgGA59X/8Q5rPnZJ+N/8gRUfHSmfL\nPn2y+Mh/Ssv4SekYvmONEgIAAAAAsKZTQPCqskzfX92Z5nOnpOEX07seb+6f1k8cl9aTxqdzs81r\nEBAAAAAAgLWJAmJd19GRhh//MM3nTknfB3/X5XjnxoPTeuLJaT3+kykHbliDgAAAAAAArI0UEOuq\n1tY0XndNmi+Ymvqn/tLlePvW26R1/KS0fXR00tRUg4AAAAAAAKzNFBDrmGLB/DRd/p00fefC1M2d\n2+X80ne9Oy2nnp4lH/xwUl9fg4QAAAAAAPQGCoh1RN2zz6TpovPSNO3KFC2LupxfctDBaTn19Cx9\nz75JUdQgIQAAAAAAvYkCYh0wYPyJ6fefN6bo6FjpXFlfn8VHHJWWCZPTseNONUoHAAAAAEBvpIBY\nBzTe+L2Vfl42N6f142PTetKEdG6+RY1SAQAAAADQmykg1mGdG2+c1k+enNbjxqUctFFPxwEAAAAA\noBdRQKyDOrbcKi3jJ6XtY8ckTU09HQcAAAAAgF5IAbEOWbrru9Ny6mlZ8qHDkvr6no4DAAAAAEAv\npoBYB7QdeVTajhmbpfvulxRFT8cBAAAAAGAdoIBYB7xy4WU9HQEAAAAAgHVMXU8HAAAAAAAAeh8F\nBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAA\nAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAA\nUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkF\nBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAA\nAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAA\nUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkF\nBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAA\nAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAA\nUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkF\nBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAA\nAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAA\nUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkF\nBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAA\nAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAA\nUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkFBAAAAAAAUDkF\nBAAAAAAAULk+PR1gTfLYY4/lkksuyX333Zd58+Zl4MCB2WmnnXLMMcdk5MiRb3ndRYsW5corr8zP\nfvazPPPMM1m8eHGGDh2a/fffP+PGjcuQIUMqvAsAAAAAAOh5RVmWZU+HWBNMnz49kydPTnt7e4qi\nWPbz1/56jj322Hzxi1980+vOnDkzJ554YubMmfO6dV9be4MNNsh3vvOd7Lzzzqt3AysxZ84r3bY2\nyaBB/VNfX5eOjs7Mn7+op+MAFbG3ofeyv6H3sr+hd7K3ofeyv9dMgwcPqGwtr2BK8uijj+Yzn/lM\nOjo6suuuu2batGm55557cuONN+Z973tfkmTatGm59tpr39S6c+fOzdixYzN37tysv/76+fKXv5yf\n//znueOOO3LmmWemqakpL7/8ciZOnJiWlpbuuDUAAAAAAOgRCogkU6ZMSVtbW7bYYotcccUV2X33\n3bPBBhtkxx13zNSpU/OBD3wgZVlm6tSpb6oo+PrXv56XXnopzc3NueKKKzJ69Ohssskm2XzzzTN2\n7NhMmTIlZVlm9uzZuemmm7rxDgEAAAAAoLbW+QLiz3/+c2bMmJGiKHLKKaekqalpuZkzzzwzdXV1\nefHFF3PHHXes0rrz5s3Lbbfdtmzd4cOHLzez//77Z6uttkqfPn3yyCOPrPa9AAAAAADAmmKdP4T6\nzjvvTJIURZEDDjhghTNvf/vbM2zYsDzyyCOZPn16Dj/88C7Xve2229LR0ZGmpqZ8/OMff8O5H/7w\nh2loaHhL2QEAAAAAYE21zj8BMXPmzCTJ0KFDM3DgwDecGz58eMqyzMMPP7xK6/7hD39Ikuyyyy5p\nbGx83Wft7e3Lfq98AAAAAACgN1rnn4B47rnnkiSbbbbZSueGDh2aJHnhhRfS2dmZurqVdzePPfZY\niqLIlltumSSZPn16rr766jz44INpbW3N4MGDc/DBB+eUU07JkCFDKrgTAAAAAABYc6zzT0AsWLAg\nRVFk/fXXX+ncgAEDkiRlWebll1/uct05c+YkSQYOHJgvf/nLmTBhQu655560tbWlKIrMnTs33/3u\nd3PYYYflwQcfXP0bAQAAAACANcg6X0AsXrw4SZZ7TdL/1q9fv+WuWZlFixYlSf7zP/8z119/ffbY\nY49ce+21eeihh3L33XfnrLPOSv/+/fPiiy9mwoQJmTt37mrcBQAAAAAArFnW+QKiq1cpvVVtbW1J\nkrlz52bvvffOFVdckXe/+91paGjIhhtumDFjxuSiiy5KXV1d5s+fn4svvrhbcgAAAAAAQE9Y58+A\naG5uTtL1Uw1//3lXT0u8NtPS0pKiKHLGGWekvr5+uZndd989+++/f37xi1/kjjvuyBe/+MU3mX7V\nbLhhc4qi6Ja1SerqimX/HTSofw+nAapib0PvZX9D72V/Q+9kb0PvZX/3fut8ATFgwICUZZmFCxeu\ndO61cx/q6+uzwQYbdLlu//7909LSkgEDBmSHHXZ4w7l/+Id/yC9+8YvMmjUrixYtSv/+1W+0Pn2W\nLz+oXlEUqa9X9EBvY29D72V/Q+9lf0PvZG9D72V/917rfAGx1VZb5b777stzzz230rnnn38+STJk\nyJBVWnezzTbLnDlz0tDQsNK59dZbb9nvFy9e3C0FRHt7hycgulFdXZGiKFKWZTo7y56OA1TE3obe\ny/6G3sv+ht7J3obey/5eM9XXV3dswTpfQGy//fZJkmeffXalTyA8/PDDKYoiw4cPX6V1hw0blt/9\n7ndZsGBBWlpalr3q6X977fDpPn36ZNCgQW/hDrq2YEFLt6zLqwYN6p/6+iKdnWXmz1/U03GAitjb\n0HvZ39B72d/QO9nb0HvZ32umwYMHVLbWOn8I9X777Zck6ejoyIwZM1Y488ILL2TmzJlJkpEjR67S\nuvvvv3+SpLOzMz/96U/fcO6uu+5Kkuy6666rnBkAAAAAANZ063wBsfnmm2fEiBEpyzLf/va3V3gW\nxNe//vV0dnZmww03zKhRo1Zp3X333TdDhw5NWZaZMmVK5s+fv9zMbbfdlgceeCBFUeTII49c7XsB\nAAAAAIA1xTpfQCTJF77whdTV1eWpp57KmDFjctddd2XBggV55JFHMnHixNx+++0piiKnnnpqGhsb\nl103a9asfOADH8ghhxySs88++3Vr1tfX5//+3/+burq6PP/88znqqKPywx/+MLNnz87f/va3XHjh\nhfnc5z6Xoijyrne9K0cccUStbxsAAAAAALrNOn8GRJLstNNO+epXv5qzzjorjz/+eMaNG/e6z4ui\nyPHHH5/Ro0e/7uft7e156qmnUhRFZs+evdy6++yzT/793/89X/rSl/L888/n85///HLr7rjjjpky\nZYpDogEAAAAA6FUUEP/tiCOOyE477ZRLL7009957b+bOnZvm5ubsvPPOOeaYY3LggQeu8LrXioM3\nKhA++MEPZrfddsvll1+eO++8My+88EIaGhqy9dZbZ9SoUfnIRz6ShoaGbrsvAAAAAADoCUVZlmVP\nh6B7zZnzSk9H6NUGDeqf+vq6dHR0Zv78RT0dB6iIvQ29l/0NvZf9Db2TvQ29l/29Zho8eEBleTcb\niQAAIABJREFUazkDAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwC\nAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAA\nAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAA\nqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwC\nAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAA\nAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAA\nqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwC\nAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqJwCAgAAAAAAqFyfnvrijo6O/PGPf8wf//jHzJ8/P4sW\nLcqZZ56ZJHn88cfT0dGRHXbYoafiAQAAAAAAq6HmBURnZ2cuu+yyXHnllZk7d+7rPnutgPjxj3+c\niy66KHvvvXf++Z//OVtuuWWtYwIAAAAAAKuhpq9gWrRoUY499tj8x3/8R+bMmZOyLJf9+nvPPvts\nyrLMr3/963zkIx/J73//+1rGBAAAAAAAVlNNC4jTTz89DzzwQMqyzJZbbplJkyblxBNPXG7uoIMO\nyhZbbJGyLLNw4cJMmjQpCxcurGVUAAAAAABgNdSsgJg+fXruvPPOFEWRMWPG5Mc//nHGjx+fXXfd\ndbnZD37wg7n11ltzxBFHJElmzZqV66+/vlZRAQAAAACA1VSzAuKmm25Kkmy33XY566yz0qfPyo+f\n6NOnT772ta/lne98Z5LkZz/7WbdnBAAAAAAAqlGzAuKhhx5KURQZNWpUiqJYpWuKosjhhx+esizz\n5JNPdnNCAAAAAACgKjUrIBYsWJAkGTp06Ju6bpNNNkny6gHWAAAAAADA2qFmBcR6662X5H+KiFU1\ne/bsJMkGG2xQeSYAAAAAAKB71KyAeMc73pEk+fnPf/6mrvvRj36Uoiiy7bbbdkcsAAAAAACgG9Ss\ngDj44INTlmV+9atf5ZZbblmla84555w8/PDDSZKDDjqoO+MBAAAAAAAVqlkB8bGPfWzZeQ5nnHFG\n/u3f/i1PPvlklixZ8rq5pUuX5r777svJJ5+cCy+8MEVRZKONNsrRRx9dq6gAAAAAAMBqKsqyLGv1\nZY888kg+8YlPZNGiRSmKYtnPy7JcVjS89NJLaW9vX/bzfv365fLLL89uu+1Wq5i9zpw5r/R0hF5t\n0KD+qa+vS0dHZ+bPd1g69Bb2NvRe9jf0XvY39E72NvRe9veaafDgAZWtVbMnIJJk+PDhuf766zN8\n+PCUZbns12tlxNy5c7N06dJlP99yyy0zbdo05QMAAAAAAKxl+tT6C7fddtv84Ac/yF133ZXbbrst\nDz30UGbNmpVFixalsbExG220UXbeeee8973vzfvf//7U19fXOiIAAAAAALCaalZAzJo1K0OGDFn2\ntMM+++yTffbZp1ZfDwAAAAAA1FDNXsH0pS99Kfvtt1/OP//8Wn0lAAAAAADQQ2r2BMSjjz6a+fPn\n55VXHIgMAAAAAAC9Xc2egHiteNhxxx1r9ZUAAAAAAEAPqVkBsc022yRJHnvssVp9JQAAAAAA0ENq\nVkCcfvrpKYoiV111VW6//fZafS0AAAAAANADanYGxA477JB/+Zd/yVe/+tWcdtpp2WKLLTJixIhs\ns802WX/99dPQ0NDlGocffngNkgIAAAAAAKurZgXEAQccsOz3ZVnm6aefztNPP73K1xdFoYAAAAAA\nAIC1RM0KiLIsV/pnAAAAAACg96hZAfH1r3+9Vl8FAAAAAAD0sJoVEEcccUStvgoAAAAAAOhhdT0d\nAAAAAAAA6H1q9gTEijzzzDP5/e9/n7lz56a1tTWNjY1529velu233z7bbLNNT0YDAAAAAABWQ48U\nELfeemsuuOCCPPHEE284s8UWW2TChAk57LDDapgMAAAAAACoQk0LiM7Oznzxi1/MzTffnCQpy/IN\nZ//617/mjDPOyIwZM/LNb34zdXXeFgUAAAAAAGuLmhYQX/va13LTTTclSerr6zNy5Mjsvffe2Xzz\nzdPU1JRFixblr3/9a+65557cdddd6ezszK233pohQ4bkjDPOqGVUAAAAAABgNdSsgPjjH/+Ya665\nJkVRZIsttsg555yTHXbYYYWz48aNy6OPPprTTjstf/3rX3PFFVfkiCOOyHbbbVeruAAAAAAAwGqo\n2XuNvve976UsyzQ1NeWyyy57w/LhNcOGDctll12W5ubmZdcDAAAAAABrh5oVEPfdd1+KoshRRx2V\nTTfddJWu2XTTTXPUUUelLMvcf//93ZwQAAAAAACoSs0KiNmzZydJdtlllzd13Wvzf/vb3yrPBAAA\nAAAAdI+aFRCvaW9vf0vznZ2d3REHAAAAAADoBjUrIF577dJvfvObN3XdAw88kCTZZJNNKs8EAAAA\nAAB0j5oVEHvttVfKsszNN9+cP/3pT6t0zcyZM3PzzTenKIrsvffe3ZwQAAAAAACoSs0KiDFjxqSu\nri5Lly7NuHHjctddd610/le/+lU++clPZunSpamrq8vo0aNrlBQAAAAAAFhdfWr1Rdtss01OPvnk\nnH/++Zk3b14++clPZrvttstee+2VzTffPE1NTWltbc0zzzyTe+65J4899ljKskxRFDnxxBOz7bbb\n1ioqAAAAAACwmmpWQCTJpEmTsnjx4lx66aVJksceeyyPPfbYCmfLskySHHfccTnttNNqlhEAAAAA\nAFh9NXsF02s+97nP5Zprrsl+++2Xvn37pizL5X7V19fngAMOyLRp03LGGWfUOiIAAAAAALCaavoE\nxGtGjBiRiy++OEuWLMmjjz6aefPmZdGiRWlqasrgwYMzbNiwNDQ09EQ0AAAAAACgAj1SQCRJR0dH\n6urqsuuuuy732YwZMzJixIist956PZAMAAAAAABYXTV/BdPzzz+fL3zhC9ljjz1y7733Lvf5rFmz\nctJJJ2XffffNWWedlfnz59c6IgAAAAAAsJpqWkDcf//9+fCHP5ybbropra2t+ctf/rLczDPPPJMk\naWtry4033pjDDz88Tz75ZC1jAgAAAAAAq6lmBcS8efMyceLELFy4MGVZZquttsqmm2663Nw222yT\nf/7nf87uu++esiwze/bsnHLKKWlpaalVVAAAAAAAYDXVrIC46qqr8tJLL6UoikyaNCk/+clPcuCB\nBy43N2jQoIwePTpXX311zjzzzCSvPhVx3XXX1SoqAAAAAACwmmpWQMyYMSNFUWS//fbL+PHjV+ma\n4447Lu95z3tSlmVuv/32bk4IAAAAAABUpWYFxNNPP50kOeigg97Uda89JfHEE09UngkAAAAAAOge\nNSsgyrJMkvTv3/9NXbfRRhslSdrb2yvPBAAAAAAAdI+aFRCvHTj98MMPv6nr/vSnPyX5nyICAAAA\nAABY89WsgNhtt91SlmVuvPHGzJo1a5WuWbBgQW644YYURZHdd9+9mxMCAAAAAABVqVkBMXr06CTJ\nwoULc9xxx+XRRx9d6fyTTz6ZE044IfPnz0+SHH300d2eEQAAAAAAqEafWn3RsGHDcuyxx+aqq67K\nU089lSOPPDLvete7sttuu2Xo0KFpbGxMW1tbXnjhhTz44IP5zW9+s+zciI985CMZMWJEraICAAAA\nAACrqWYFRJKceeaZWbhwYX7wgx8kSR588ME8+OCDK5x9rXwYNWpU/s//+T81ywgAAAAAAKy+mhYQ\ndXV1+drXvpZRo0bliiuuyD333JPW1tbl5urr67PHHnvkuOOOywEHHFDLiAAAAAAAQAVqWkC8Zs89\n98yee+6ZJUuW5IknnsjcuXPz0ksvpampKYMGDcqwYcPS1NTUE9EAAAAAAIAK9EgB8ZqGhoYMHz68\nJyMAAAAAAADdoGYFRFmWKYpihZ8tWLAgN954Y/70pz9l4cKF2WKLLXLggQdm7733rlU8AAAAAACg\nQt1aQNx333257LLL8tBDD+XII4/M5z73ueVmbr311nzpS19KW1vb634+bdq07LrrrjnnnHPytre9\nrTtjAgAAAAAAFavrroW/+c1vZuzYsZkxY0ZefPHFzJ8/f7mZn/70p/nMZz6T1tbWlGW53K8HH3ww\nH/3oR/O3v/2tu2ICAAAAAADdoFsKiEsuuSSXXnrpsiJhyJAh2WKLLV43s3Dhwvzrv/7rslczDRw4\nMGeffXYeeOCBzJgxIxMnTkx9fX1mz56dL3/5y90REwAAAAAA6CaVv4Jp7ty5ueCCC5IkG2ywQb76\n1a/m4IMPXm7uu9/9bubMmbPsz+edd15GjBiRJFlvvfUyceLEbLzxxvmXf/mX3HXXXbn//vuzxx57\nVB0XAAAAAADoBpU/AXHbbbelpaUlffr0ySWXXLLC8iFJfvzjHydJiqLI/vvvv6x8+Hsf+9jHsu22\n2yZJfvKTn1QdFQAAAAAA6CaVFxAzZsxIkowcOTK77LLLCmdmzZqVmTNnpiiKJMlhhx32husdeOCB\nKcsyv/3tb6uOCgAAAAAAdJPKC4innnoqRVFkr732esOZX//610mSsixTV1eXfffd9w1nt9566ySv\nlhYAAAAAAMDaofICYt68eUmSIUOGvOHM/fffn+TV1y/tsMMOWX/99d9wtn///klePbQaAAAAAABY\nO1ReQJRl2eXMvffeu+z3e+6550pn58+fn+TVA60BAAAAAIC1Q+UFxEYbbZQkmTt37go/f+aZZ/Ls\ns88u+/Pee++90vUef/zxJMmGG25YUUIAAAAAAKC7VV5AvOMd70iS/O53v1vh57fffvuy3zc2Nq70\nCYjOzs5Mnz49RVFku+22qzYoAAAAAADQbSovIA444ICUZZnp06fnL3/5y+s+W7JkSa677rokr57/\ncNBBB6WhoeEN17rqqqsye/bsJMl+++1XdVQAAAAAAKCbVF5AfOhDH8qgQYOyZMmSnHDCCfnlL3+Z\nJUuW5M9//nNOPfXUZa9fKooiY8eOfcN1pk+fnrPPPjtFUWT99dfPQQcdVHVUAAAAAACgm/SpesEB\nAwbkC1/4Qj7/+c/nhRdeyKc+9anXfV4URZLk4x//eHbZZZfXffbcc8/lvvvuy6233ppf/epXKcsy\nRVHk05/+dAYMGFB1VAAAAAAAoJtUXkAkyYc//OEURZGzzjorra2ty33+0Y9+NGecccZyP7/66qtz\nxRVXJEnKskzyalFx9NFHd0dMAAAAAACgm3RLAZEkhx56aEaOHJnvf//7efjhh7Nw4cJsvvnmOfTQ\nQ/Oud71rhdcMHjx4WfGwwQYbZPLkyRkzZkx3RQQAAAAAALpJtxUQyaslwgknnLDK87vvvnsmTpyY\nHXbYISNHjky/fv26MR0AAAAAANBdurWAeLN22WWX5c6FAID/x959x2tZFn4c/96HDSJDMUUFM3Ig\nhuYoTRypCbmzMkeWmaU21PyZihMrR0sSTc3sZ5KmiSNXjlQwXEjlFjVZsvcQBOWc5/cHP06eOCy7\nETzn/X69eknPc93XfZ2D1z/Px/u5AAAAAPjwqVrTCwAAAAAAABoeAQIAAAAAACidAAEAAAAAAJRO\ngAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAA\nAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACg\ndAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSCRAA\nAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAAAAAA\nAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6A\neI/XXnstp59+evbYY4/06NEju+22W0444YT87W9/K/U+b7/9dvbbb79stdVWueKKK0qdGwAAAAAA\n1gZN1/QC1hYPP/xwTj755CxatChFUSRJpk+fnsGDB2fw4ME55phj0rdv31LudfHFF2fMmDG19wEA\nAAAAgIbGExBJXnnllZx22mmprq5Oz549M3DgwDz11FMZNGhQ9t133yTJwIEDc9NNN/3X9xo8eHD+\n9Kc/iQ8AAAAAADRoAkSS/v37Z8GCBenSpUuuv/767LjjjmnXrl222WabDBgwIL17906lUsmAAQMy\nf/78932fGTNm5JxzzklRFKlUKiX+BAAAAAAAsHZp9AFi5MiRGTJkSIqiyIknnphWrVotNebMM89M\nVVVVZs2alQcffPB93+ucc87J9OnTc+ihh/43SwYAAAAAgLVeow8Qjz32WJKkKIrsueee9Y7ZcMMN\ns/XWWydZfFbE+3HrrbfmkUceycYbb5yzzz77fc0BAAAAAAAfFo0+QIwYMSJJ0rlz57Rv336Z47p3\n755KpZKXXnpple8xduzYXHzxxamqqsoll1ySNm3avO/1AgAAAADAh0GjDxDjx49PkmyyySbLHde5\nc+ckyaRJk1JTU7PS89fU1OSHP/xh3n777Xzta1/Ljjvu+P4XCwAAAAAAHxKNPkDMnDkzRVFk3XXX\nXe64tm3bJkkqlUrmzJmz0vNfffXVefbZZ9OtW7eceuqp/9VaAQAAAADgw6LRB4iFCxcmSVq2bLnc\ncS1atFjqmhV58cUX8+tf/zpNmzbNT3/60zRv3vz9LxQAAAAAAD5EGn2AqKpaPb+ChQsX5vTTT091\ndXVOOumk2kOsAQAAAACgMWi6phewprVu3TrJip9qeO/7K3paIkkuvfTSjBo1Kj179swJJ5zw3y3y\nv9ShQ+sURbFG19CQVVUVtf/s2NEB49BQ2NvQcNnf0HDZ39Aw2dvQcNnfDV+jDxBt27ZNpVLJW2+9\ntdxxS859aNKkSdq1a7fcsUOHDs1NN92Uli1b5pJLLlltT1msrKZNm6zR+zcWRVGkSROhBxoaexsa\nLvsbGi77GxomexsaLvu74Wr0AWKzzTbLsGHDMn78+OWOmzhxYpJkgw02WOGc9957b5JkwYIF6dOn\nzzLHVSqVXHHFFbniiiuSJI888kg6d+68sktfaYsWVXsCYjWqqipSFEUqlUpqaiprejlASextaLjs\nb2i47G9omOxtaLjs77VTkybl/Qf1jT5AbLnllkmScePGZd68eWnTpv5HfV566aUURZHu3buv1Lwr\n+sC/UqnUGbc6A8HMmfNX29wkHTu2SZMmRWpqKpkxY96aXg5QEnsbGi77Gxou+xsaJnsbGi77e+3U\nqVPb0uZq9AFi9913T5JUV1dnyJAh+fznP7/UmEmTJmXEiBFJkl69eq1wzgsvvDDnnXfecsdsv/32\nKYoi3/rWt2rPiGjVqtWqLh8AAAAAANZKa/ZwgrXApptumh122CGVSiWXX355vWdBXHzxxampqUmH\nDh1y8MEHr3DOZs2apVWrVsv9X31jAQAAAACgoWj0ASJJzjrrrFRVVWX06NE58sgj8/jjj2fmzJl5\n+eWX893vfjcPPPBAiqLI9773vbRs2bL2usmTJ6d3797p06dPLrvssjX4EwAAAAAAwNql0X8FU5L0\n6NEjP/nJT3Luuefm9ddfz3HHHVfn/aIocuyxx+aII46o8/qiRYsyevToFEWRKVOmfJBLBgAAAACA\ntZoA8f8OPfTQ9OjRI9ddd12efvrpTJs2La1bt862226bo446KnvttVe9130Qh0gDAAAAAMCHTVGp\nVCprehGsXlOnzl3TS2jQOnZskyZNqlJdXZMZM+at6eUAJbG3oeGyv6Hhsr+hYbK3oeGyv9dOnTq1\nLW0uZ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACid\nAAEAAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAA\nAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA\n6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAA\nAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAA\nAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0A\nAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAA\nAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDp\nBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAA\nAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAA\nSidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQAB\nAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAA\nAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkE\nCAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAA\nAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABK\nJ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEA\nAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAA\nUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQI\nAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAA\nAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEon\nQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAA\nAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQ\nOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgA\nAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAA\ngNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidA\nAAAAAAAApWu6phewNnnttddy7bXXZtiwYZk+fXrat2+fHj165KijjkqvXr3e97xDhgzJbbfdluee\ney4zZsxI8+bN07Vr1+yxxx756le/mo4dO5b4UwAAAAAAwJpXVCqVyppexNrg4Ycfzsknn5xFixal\nKIra15f8eo455pj07dt3leasrq7OGWeckXvuuafOnO+de7311suVV16Z7bbb7r/7AZZj6tS5q21u\nko4d26RJk6pUV9dkxox5a3o5QEnsbWi47G9ouOxvaJjsbWi47O+1U6dObUuby1cwJXnllVdy2mmn\npbq6Oj179szAgQPz1FNPZdCgQdl3332TJAMHDsxNN920SvP+/Oc/r40P++yzT/74xz/mqaeeyt13\n353/+Z//SevWrTN9+vSccMIJmTJlyur40QAAAAAAYI0QIJL0798/CxYsSJcuXXL99ddnxx13TLt2\n7bLNNttkwIAB6d27dyqVSgYMGJD58+ev1JxTpkzJwIEDUxRFDjrooAwYMCDbbbdd2rVrl27duuW4\n447LDTfckKZNm2b27Nn5zW9+s5p/SgAAAAAA+OA0+gAxcuTIDBkyJEVR5MQTT0yrVq2WGnPmmWem\nqqoqs2bNyoMPPrhS8/71r3/NokWLkiSnnHJKvWN69OiRffbZJ5VKJYMHD37fPwMAAAAAAKxtGn2A\neOyxx5IkRVFkzz33rHfMhhtumK233jrJ4rMiVsaUKVPSqlWrrL/++tloo42WOa5r16614wEAAAAA\noKFo9AFixIgRSZLOnTunffv2yxzXvXv3VCqVvPTSSys17ymnnJJ//vOfuf/++5c7bsyYMUmSdddd\ndyVXDAAAAAAAa79GHyDGjx+fJNlkk02WO65z585JkkmTJqWmpmal52/Tps0y35syZUoeffTRFEWR\nHXbYYaXnBAAAAACAtV2jDxAzZ85MURQrfAKhbdu2SZJKpZI5c+aUcu9zzz03CxcuTJJ6yUnlAAAg\nAElEQVQcffTRpcwJAAAAAABrg0YfIJYEgJYtWy53XIsWLZa65r9x0UUX1R5+feCBB2annXb6r+cE\nAAAAAIC1RaMPEFVVH/yv4OKLL84NN9yQoiiy5ZZbpl+/fh/4GgAAAAAAYHVquqYXsKa1bt06yYqf\nanjv+yt6WmJZ3n333fTt2zd33313iqJIt27dct1116VVq1bva76V1aFD6xRFsVrv0ZhVVRW1/+zY\ncdlnfgAfLvY2NFz2NzRc9jc0TPY2NFz2d8PX6ANE27ZtU6lU8tZbby133JJzH5o0aZJ27dqt8n1m\nz56d73znOxk+fHiKokiPHj3ym9/8Jh06dHhf614VTZs2We33ICmKIk2aCD3Q0Njb0HDZ39Bw2d/Q\nMNnb0HDZ3w1Xow8Qm222WYYNG5bx48cvd9zEiROTJBtssMEq32Ps2LE5/vjjM2bMmBRFkd133z39\n+/df7U8+LLFoUbUnIFajqqoiRVGkUqmkpqayppcDlMTehobL/oaGy/6GhsnehobL/l47NWlS3rEF\njT5AbLnllkmScePGZd68eWnTpv5HfV566aUURZHu3buv0vyvv/56vva1r2XGjBkpiiJf/vKXc/75\n53+gZ0/MnDn/A7tXY9SxY5s0aVKkpqaSGTPmrenlACWxt6Hhsr+h4bK/oWGyt6Hhsr/XTp06tS1t\nrkZ/CPXuu++eJKmurs6QIUPqHTNp0qSMGDEiSdKrV6+VnvvNN9/MscceWxsfTjnllPTr12+NHHwN\nAAAAAAAfpEb/Sfimm26aHXbYIZVKJZdffnm9Z0FcfPHFqampSYcOHXLwwQev1LyLFi3KKaeckmnT\npqUoivTt2zff/va3y14+AAAAAACslRp9gEiSs846K1VVVRk9enSOPPLIPP7445k5c2ZefvnlfPe7\n380DDzyQoijyve99Ly1btqy9bvLkyendu3f69OmTyy67rM6cN998c+3XNvXp0yeHHXZY5s+fv9z/\nAQAAAABAQ9Hoz4BIkh49euQnP/lJzj333Lz++us57rjj6rxfFEWOPfbYHHHEEXVeX7RoUUaPHp2i\nKDJlypQ67/3+979PklQqldx333257777VriOJV/zBAAAAAAAH3YCxP879NBD06NHj1x33XV5+umn\nM23atLRu3TrbbrttjjrqqOy11171XlcURZ1/JsnMmTMzbty4Oq+tyKqMBQAAAACAtV1RqVQqa3oR\nrF5Tp85d00to0Dp2bJMmTapSXV2TGTPmrenlACWxt6Hhsr+h4bK/oWGyt6Hhsr/XTp06tS1tLmdA\nAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAA\nAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6\nAQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAA\nAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA\n0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AA\nAAAAAAClEyAAAAAAAIDSCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAA\nAJROgAAAAAAAAEonQAAAAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoB\nAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAA\nAACgdAIEAAAAAABQOgECAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDS\nCRAAAAAAAEDpBAgAAAAAAKB0AgQAAAAAAFA6AQIAAAAAACidAAEAAAAAAJROgAAAAAAAAEonQAAA\nAAAAAKUTIAAAAAAAgNIJEAAAAAAAQOkECAAAAAAAoHQCBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAA\nlE6AAAAAAAAASidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgEC\nAAAAAAAonQABAAAAAACUToAAAAAAAABKJ0AAAAAAAAClEyAAAAAAAIDSNV3TCwAAAAAA+E9/+cs9\nueiifu/7+r59z0+fPgeUuKJlu/baq3LDDb9LkyZNMnjwU6XNe+KJx+XFF5/PjjvunMsuu7K0eeGD\nIkAAAAAAAGuloig+0OvWNkVRNJifhcZJgAAAAAAA1jr77ff57LXXPvW+d/TRX8qUKZPziU9sl1/8\n4vJUKkuPad68+Wpe4b+1a9cuG2+8aZo2Lffj1k6dNkjnzpukU6cNSp0XPigCBAAAAACw1qmqqkrL\nli3rfW/JUwFVVVVp0aL+MR+kL3/5yHz5y0eWPm+/fheVPid8kBxCDQAAAAAAlM4TEAAAAABAg3XP\nPXfm0kt/kg037JyBA29J//4/y+DBj6S6ujqdO2+cU089Pdtt98kkSU1NTR599K8ZPPiRjBjxcmbN\nmpmampqsu267bLXV1unde//sscdnl7rHsg6hHj58WE499Tu1r48ePSo33XRDhg8fllmzZqZt23Wz\n3XafzBFHHJ2ttuq+1LzLOoR6yf2WvP7kk4/n9tv/lBEjXsm8efPSqVOn7Lprrxx11Ney/vrr1/t7\nqVQqGTLkkdxxx20ZPXpk5s17K5tu2iV9+hyQww47PD/72UW59967csABh+SMM85epd/5iy++kDvu\n+FOef/65TJs2NS1atMhHPrJhdtxx53zxi1/JRht1Xua1o0aNzB133Jp//GN4Jk+elKKoSteuXbPX\nXvvksMMOT4sWLeq9bujQx3LffXfn5ZdfzOzZs9KmzTr52Me6Ze+9P5f99z8oTZo0WeqaQw/9fKZN\nm5q+fc9Px47r5de//lXefHNs2rZtm5133iVnn31B7dhFixblrrvuyCOPPJRRo97I22+/nQ4dOma7\n7bbPF7/4lWy99Tar9DtqLAQIAAAAAKARqOS8887Mk08+XvsVTmPGjEqXLl2TJDNnzszpp5+cV199\nZamDn6dPn5ahQx/L0KGPva8P5JPkb38bnPPPPzuLFr1b+9rMmTPyyCMPZfDgh3PeeT/O3nvvW+ea\n5R1CveT1q6++Ijfe+Ps64yZOnJBBg27Ogw/el6uuui5dumxW59pFixalX79zMnjww3Wue+ONf2XA\ngMvy2GODs/76nd7XAdi3335r+vf/WSqVSu318+fPz6hRIzNy5Bu5445B+fGPf5pdd91tqWtvueXG\nXHXVgFRXV9e596uvjsiIEa/kL3+5J/37/zrrrffvqLJgwYKcd95ZefLJoXWumTNndv75z7/nH/8Y\nnjvvHJRLLvllNtjgI0v9DouiyPPPP5u//OWe1NTUJFn870Lr1q1rx02aNDGnn35yRo8eVeceU6dO\nyYMP3p8HH7w/xxzzjRx//Imr/Ptq6AQIAAAAAFgN5s5NzjijZf72tyZZuHDVP8j9sGjRopJevapz\n6aUL0rbtml7Nsk2aNDGTJ0/Kl798RL7ylaOzYMGCvPzyi+nYcb0kyY9/fH5effWVNG3aNF//+jez\nxx6fTceO62XWrJl54YXn8rvf/SZTpkzOvff+Ofvvf1B69Nh2pe9dqVTSr9856dixY771re9kxx13\nSk1NJUOGPJyrr74iCxcuzC9/eUk+85leS517UanvhO3/f/3FF5/P8OHD0rPn9vnGN76Vbt22yKxZ\nM3Pbbbfk9ttvzdy5c9O//y/yy18OqHPtFVdcVhsfPve5PvnKV47OBht8JCNH/ivXXHNlnnvun+8r\nPkyYMD4DBvwySbLrrrvlq189NhtvvGneffedPPvsP3Lllb/KjBnTc/HFF2bQoLuStKm99v77780V\nV/RPURTZaqutc9xxJ2TrrbvnrbfeykMP3Z/rr/9txowZnQsvPDe/+tVVtdede+4ZeeqpJ1IURfbd\nd7988YtfySabdMmMGdNz//335uab/5DXX38tP/jB9/Lb395Q77ki99zz52y44UY566zz8tGPfiwv\nvfRCunTpkmRxPDnllO9k/Pg307p16xx77PHp1WvPrLtuu7z55pjccstNefTRv2bgwP9N27Zt85Wv\nHL3Kv7eGTIAAAAAAgNXgjDNaZtCgZmt6GR+AIoMGVaUokiuvXLCmF7NMRVFk++13yPe+94Pa1zbd\ndPGHzG+88a8MG/ZkiqLI8ceflCOP/GrtmHXXXTddunRNt25b5JvfXPz6008/sUoBoqamJi1btsw1\n1/xvnf96/7DDDk+S9O//88ydOzfDhw/LbrvtvtLzLly4MD17bp/LL786VVVVtes99dQfZvr0aRky\n5NH8/e/D8tZbb2WdddZJkowdOzp33DEoRVHkkEMOyw9+cEbtfNtt98lcfvnVOeWUk/L888+ucoR4\n/PG/ZdGiRWnTpk0uuujndb726HOf65P11ls/p5xyUmbPnpXhw5/JgQf2TrL4KYYl8WGbbXrkV7+6\nOs2bN0+StGvXPl//+jfTvHmLXHXV5fnnP/+el156Mdts0yOPPTa4Nj4cffTX861vnVR7v7Zt2+bb\n3/5OunXbIhdc0Ddjx47ODTf8rs6YJLVPapxzTr/07Ll9ktT5Oxg48H8zfvybadaseQYMuCZbbLFV\n7Xvdu/dIv34XZd112+XOOwflt7+9Or17H5D27duv0u+tIXMINQAAAACsBs88s/R3zjdkw4at/T/v\nXnvtXe/rlUolRxxxdPbY47M5+OBD6x2z5ZZb1X4tz6xZs1bpvkVRpE+fA+vEhyV23bVX7Z8nTpyw\nSvMmyZFHHlMbH+qbt1KpZNKkibWvP/DAX1JTU5PWrVvnpJNOXuq6Zs2a5dRTf7jK60iSd999J0lS\nXV2dWbNmLvX+DjvslIsv/kV+97sbs+OOO9e+/sQTT2T27MW/0+9859Ta+PBehx32pWy++cfyqU/t\nkvnz30qy+HyPJOnUaYN885sn1LumvffeN7vuulsqlUruuuv2ese0b9+hNj68V6VSyd1335GiKLLf\nfp+vEx/e64QTvpNmzZrnnXfeyQMP3FvvmMbKExAAAAAAsBrstFN1xoxpPP/97847V6/pJazQxz9e\n/wfI3bp9PN26Lf1h/BJvv/12XnjhuRTF4r/P6upFq3zv7t3rP6S4Q4eOtX9esGDVnyDp3r3HMubt\nUO+8S5702GGHner9OqJk8e9j4403yYQJ41dpLT17frL2fscf/7Uccshh2WWX3fLxj29RO6a+Jzye\nemrxwd1t27Zd5pMlLVq0zO9/f3Od1559dvFXRfXqtUe9EWaJvff+XJ54YmjmzJmTkSP/lc0371b7\nXlEU+fjHt6z3ujfe+Fdmz56doijSrdvH8/bbb9c7riiqsvnmH8trr43I888/m8MPP2qZa2lsBAgA\nAAAAWA0uvXRBiiJ57LGGfwbE7rtX55JL1t6vX1piZb4a59VXR+TFF5/Pm2+OzYQJ4zJ27NhMnDi+\n9oDioiiyjGMZVnDvDvW+3qzZv7+mq1KpeR/z1v8zNWv276cI3jvvxImLn4bYdNOuy523S5fNVjlA\nbLNNjxx66Bdz5523Zdq0qbn22qty7bVXpWPHjtlpp09n1117Zdddd1sqfEyZMjlJsskmXVb6XnPn\nzs3bb89PURTp2vWjyx373vcnT55UJ0Aky/4dvvfn79//Z+nf/2crXNeSn4XFBAgAAAAAWA3atl27\nz0RojFq0aLHM9157bUQuueRHef3115KkzvkH66/fKTvuuHMee2xw5s+f977u3bRp+R/FLu+/+l+W\nuXPnJMkyn35YolWrVu9rTT/4wRn55Cd3zKBBt+SFF55LpVLJzJkz88AD9+WBB+5LmzZtcuyxx9d5\nSmD27Nkrtab3mjfv338PK1prq1b/nnf+/KWfYmjevP5/L+bNe6v2zyt7Hsb8+fNXalxjIUAAAAAA\nAI3ahAnj8/3vn5B58+alefPm6dVrz3Tv3iObb/6xbLbZ5ll//cVnNzz99BPvO0CsLZo3b5GFCxes\n8IPyBQvq/7qhlbHnnntnzz33zqxZs/LMM09l+PBheeaZpzNt2tTMmzcvV175q7Ro0TLf+MYxSf4d\nEFblK6hat/53dFjWVyMt8d6fdVXCynuDSP/+v84nP7njSl/LYgIEAAAAANCoXX/9bzNv3rw0bdo0\nV1/9v3XOLFiiUqlk7ty5a2B15dpkk03yxhv/yrhxby533IreXxnt27fPvvv2zr779k6SDBv2VM4/\nv2/mzXsrgwbdUhsgNtxwwyRZ4Vc+3XnnbZk/f1623nqbbLfdJ9O6deu8/fbbGTNm1HKvGzVqZO2f\nl9xrZXzkI/8eO2HCeAHifWg8p+AAAAAAANTjpZdeSFEU2WqrreuND0ny7LP/yLvvvpvk/Z3VsLbY\nfvsdUqlU8o9/DM/ChQvrHfPmm2MzduyYVZ77l7+8NEcc8YX86Efn1fv+zjt/Ovvuu18qlUqmTZvy\nnjUtPrx69uxZefXVEfVeW6lUcu21v85VVw3IkCGPpCiKbLttz1Qqlfztb0Nqz+ioz6OPPpwkadNm\nnXz0ox9b6Z9niy22SqtWrZMkQ4cOWea4+fPn5YAD9smXvnRQrr32qpWevzEQIAAAAACARq1Jkyap\nVCqZMGFCbWR4rzlzZtc5gLi+MR8WBx54aIqiyPz58/Lb31691PuVSiUDBlz2vuauqanJuHFv5vHH\nH8vEiRPqHfOvf72eJOnceZPa1/bZZ5+ss07bJMmvf315qqurl7rulltuzJw5c1IURfbZZ78kyUEH\nfSFJMnXqlGV+8P/oo3/Nk08OTVEU+fznD1zpsxySxed29OmzfyqVSp54Ymgee2xwveOuuuqKzJ49\nO5MnT8oWW2y50vM3BgIEAAAAANCo7bzzLkmSmTNn5MwzT8vLL7+Y2bNnZdy4N3P77bfmG984OiNH\nvlH74fUHedDwqnxgvjI++tHNc9BBX0ilUsnNN/8hF198Yf71r9czZ86cvPDCcznttO/XfmC/+P4r\nP/eXvnREmjVrlnnz5uX73z8xDzxwXyZMGJ9Zs2bl5ZdfzLnnnpkXXnguRVHksMO+XHtdq1atctJJ\n3///JzOeycknn5h//GN45syZnVGjRuaqqwbk6quvSFEU2X33PdOjxyeSJLvvvmd22WW3VCqV/OEP\n1+fCC8/NK6+8lDlz5mTs2NG55por06/fOSmKIptu2iXHH3/iKv++jj32W+nUaYNUKpWcd96Zufrq\nKzJq1MjMmTM7I0a8nAsvPDd33jkoRVFk++13yB57fHaV79GQOQMCAAAAAPjQqVQqpc11zDHfyFNP\nPZ6xY8dk2LAnM2zYk3XeL4oin/jEdmnVqlWefvrJjBs3trR7r0iZP+cSJ598WiZPnpinn34y9913\nd+677+7a94qiyC67fCajRo3M5MmT0qTJyn+E3LXrZjn99L756U9/ksmTJ+bHPz5/qTGL48Ph2X//\ng+q8fuCBh2TmzBm57rpr8vzzz+bkk09c6rrtt98hZ5/dr87rF1zwk/Trd3aefPLxPPTQ/XnoofuX\num7rrbdJv34X1zlUemW1b98+/ftfmR/+8AeZMGFcbrzx97nxxt8vdY8ePT6RH/3o0lWev6ETIAAA\nAACAD52iKFb66YAVjV133XXzm99cn4EDr8/QoUMyYcL4VCqLP3zefPOPpXfv/bP33p/L/fffm2HD\nnsrYsWMyduyYdOnSdYX3WNl1LmvMfzPvssY0a9YsP/vZr3LvvXflvvvuzsiRb+Tdd99Jly6b5aCD\nDsnBBx+Www8/JEnSvHnzFa79vfr0OSBbbrl1brvtljz77D8yZcrk1NTUpGPH9fKJT/TMAQccku23\n36Hea4855hvZZZfP5NZbb84///n3TJ8+Pc2bN0u3blukd+/9s//+By3187Ru3TqXXnpZhg4dknvv\nvbv2CYj27dtns802T58++2evvfZJ06bL/ih8RX89XbpsloEDb8ldd92eIUMezciRb2TevLfSpk2b\ndOu2Rfbb7/Pp3Xv/0p9WaQiKyupIaKxVpk6du6aX0KB17NgmTZpUpbq6JjNmzFvTywFKYm9Dw2V/\nQ8Nlf0PDZG/DmnHAAftkzpw5+da3TsrRR399tdzD/l47derUtrS5PAEBAAAAANBI3H//vXn++Wez\n5ZZb5+CDv1DvmEmTJmb27NkpiiJdu272wS6QBsUh1AAAAAAAjcSiRe/m7rvvzC9/eWkmTZpY75jf\n/e43SZKmTZtlu+3q/7okWBkCBAAAAABAI/GZz+yRVq1ap1Kp5NRTv5OHH34okyZNysyZM/LCC8/l\n/PP75i9/uSdFUeTrXz8ubduW93U8ND6+ggkAAAAAoJHo0KFDzj77gvzoR+dm/PhxueCCvkuNKYoi\nhx76xdV29gONhwABAAAAANCI7LHHXvn4x2/JrbfenOHDn679Kqb11++U7t175KCDDk3Pntuv4VXS\nEAgQAAAAAACNTOfOG+fkk09b08uggXMGBAAAAAAAUDoBAgAAAAAAKJ0AAQAAAAAAlE6AAAAAAAAA\nSidAAAAAAAAApRMgAAAAAACA0gkQAAAAAABA6QQIAAAAAACgdAIEAAAAAABQOgECAAAAAAAonQAB\nAAAAAACUToAAAAAAAABKJ0AAAAAAADRQNTU1a3oJNGICBAAAAACw1unb9/T06rVTevXaKePHj1ul\nay+77Kfp1Wun7LHHpzJt2tT/ei1PP/1k7VpefvnFOu8ddNB+6dVrp/z855es8rx33nlbevXaKXvv\n/Zn/eo3/aerUKTnnnB/m1VdfqfP6O++8U/uz3Hjj70u/L7yXAAEAAAAArHX23/+gJElRFHnooftX\n+rpFixbl4YcfTFEU+dSnds3663cqbU1FUdTzWv2vr0nTpk3N0Ud/KY89NjiVSqXeMWvbmmmYBAgA\nAAAAYK2zyy6fyXrrrZ8kefDBv6z0dU88MTSzZ89Okhx44MGrZW3vtdFGG6dz503SoUOH1X6vlTV/\n/rzMnz+/3veqqqqy8cabpnPnTdK27bof8MpobJqu6QUAAAAAAPynqqqq9O69f2688fcZN+7NjBjx\nSrbaausVXnf//fcmSTp06JBdd+21upeZq6/+3Wq/R5maNm2am2++fU0vg0bCExAAAAAAwFppydcw\nJclDD634KYg5c2bnySeHpiiK9O59QJo0abI6l7fWWsa3LsEHzhMQAAAAAMBaadNNu+QTn9guzz//\nbP761wfz3e+eutyzCx566P4sWrQoRVHUiRfv9cYb/8pdd92eZ5/9Z6ZOnZL58+elTZs22XTTrtll\nl8/ksMMOzzrrrLPSazzooP0yc+aMHHzwYfmf/zlzqfcnTBifP/7xD/n734dl8uRJWXfddvn0p3fN\nsccev8K533nnndx339154omhef31VzN79uw0aVKV9u07pHv3Hjn44C/kk5/csc74/zzQ+tvfPjZJ\natf33jEnnPDdHHXU15a67/jx43LrrX/M8OHDMmnSxBRFVTbaaKN86lO75vDDj6z3XI0777wtv/jF\nJenadbP84Q+35oUXnsstt9yYF154PnPnzkmHDh2z886fztFHfz0bb7zJCn/2/1SpVPLQQw/kwQfv\ny4gRr+Stt+ZmnXXWSZcum2W33XbPIYd8Ma1bt17m9U899UTuuefPefXVEZk+fWpatWqVLbfcOgce\neEj22mufeq9ZuHBh7rnnzjz66MMZOfKNLFjwdtq375AePT6RAw88JDvt9Kmlrhk7dnSOOupLKYoi\nt99+bx544L4MGnRLZs+enU6dOuXww4/KF77wpdrxM2fOzJ/+dFOeeGJoJk6ckEqlJh/5yEb59Kd3\nzVe+cnTWX3/9Vf5drU0ECAAAAABgrbX//gfl+eefzcyZMzJ8+LB6P/RdYsnXL227bc906dJ1qfev\nuebK3Hjj71OpVOqEjLlz5+bll1/MSy+9kHvuuSvXXPO7dOy43kqtb3mHUA8dOiQXXHB2Fi5cWDtm\n+vRpuffeuzJ48CP57Gfr/+A7WfxB9mmnnZxJkybUmX/RomTy5EmZNGliHnnkoaUiwpKxSw6fXvL/\n/3ONy1rz7bffmiuuuCzvvvtunTGjR4/KqFEjc+edg3L22Rdkzz33XubaBw26OQMGXFbnAOypU6fk\nnnv+nIceuj+XXXZltt225zKvr8+5556ZIUMeqbOmOXPm5MUXn88LLzz3/+v+TTbccKM61y1cuCAX\nXXRhHnnkoaX+zp955uk888zT2WefwTn33AtTVfXvLwwaPXpUzjrrtIwb92ad66ZNm5pHH/1rHn30\nr9lvv8/nzDPPTdOm9X/Mfv311+XPf76t9vqJEyekU6d/x5thw57KeeedlXnz3qpzj7FjR2fMmFG5\n6647cv75P85nPrP6v0psdREgAAAAAOD/2rv3+Jzr/4/jz8/OzMy5zJlqwxiRU2VFlEgqh/BNRIdv\nEeKbDl/f+Kok+iLlkFPI5JQkhWgmh5xytuUQY5tt2Gazg50+vz/229XWrs02l3Z63G+3bn1c78Pn\nfX147c31ut7v921gxMWqwrgxcvwlQMaNpKIezm1jOrso5UFfXZ/yiczbcKhxp05dNHPmNCUmJuqn\nnzblmoAIDj6voKBAGYahJ57olaN88+Yf9NVXX8owDHXo8IAGDBik2rXryDQzPvBdvnyp9u3bo4iI\nS/ryywV6441xtzTuP/44o3//e5zS09Pl4VFLr702Sj4+LRQfH68tW37U0qWL9N1366y2TU1N1Tvv\n/Evh4WFyda2gl156VW3atFPFiu66evWK9u7draVLFysuLlYLFszVo492V7Vq1Q8bHUkAACAASURB\nVOTk5KQtW3bowoXzGjr0OUnSp5/OlZdXk1w/JM9qy5ZNmj79YxmGoXr1GujFF19R8+YtlJ6eroMH\n92v+/DkKD7+kCRPe1f/+555t9UWmS5fC9Omn/1OjRndp2LB/ytu7mRITE7Vx43daunSRkpOT9fHH\nH2jZslX5fpYbN35nST4MHPi8Hn30cVWpUlWxsde0detmLV48X5GREZoxY6o++uh/2dpOnTrZknzo\n0uUx9enzrDw8ais8PEzLln2p7du3adu2LWrYsJGeey5jtUh0dJTeeGO4Ll+OlJOTk557bog6d+4q\nd/dKlj8ru3bt0JYtP8re3l5vv/0fq+Nev36t7ruvnV5//Q1VqFBBu3fvtJxL8vvvQXrrrTFKTU1R\n3br19MILL6tFi5ayt3fQiRPHtHDhPJ0+/bvGjx+n2bMXyMurSb6fV3FCAgIAAAAAAAC4DSqMGyOX\nNSuLehh/C/s1KyXDUNznX9i8bxcXF3Xq1EXff79eO3b4a+zYt+Xk5JSj3g8/bJAklS9fXg8/nPPb\n+X5+y2QYhu65x0sffjgt2/kQ1apVU4sW92rIkAH644+z2rt3zy2P+7PPZigtLU1VqlTR3LmLVbly\nZUmSu3slDR48THXq1NOECe9Ybbtr1y8KDj4vwzD0zjvvqWPHhyxlFStWVIMGDVW9+h2aMOEdpaWl\n6eDBfXr00cclZTwvFxcXS30nJ6dsv85NUlKSPvtsugzDUIMGjTRnzgKVL+9qKe/atZtat26jF198\nXpcvR2rKlPf19dfrcqykSEnJ+EB9zpxFlvu6u1fS0KEv6/r161qz5msFB5/X+fPnVKWKd76e5Y4d\n/jIMQ+3b36+XX34t27MYPHiYbty4oeXLl2jfvl+VmJiocuXKSZKOHz+qzZt/kGEYevbZgXr11ZHZ\n2k6a9JHGjHld+/bt0ddff6X+/Z+Tg4ODFi+er8uXI2VnZ6cpU6ardes2lnbe3s01efI0ffzxB9qw\n4Vv9+OP3evTRx3MkY0zTlJtbRX3wwceW8fTs+ZSlfNq0D5WamqI6derqiy++lKvrn9t+3X//g2rd\n+j79859DdebMaU2fPlXz5i3O17MqbjiEGgAAAAAAALgNHPfvLeoh/K0c9/162/ru3v1JSVJCQoJ2\n7tyRozzjfIBNMgxDjzzymJyds3/gnpqaqoce6qRHH31czz//gtXDqe3s7NSsWQtJUkxM9C2NNyYm\nRgcP7v//b+wPtiQfsurcuYtatLjXans3Nzf16fOsunR5LFvyIat7722V5X63Nl4pY7uo6OgoSdLI\nkWOyJR8yValSVa++OlKmaerSpTD9+utuq3317v2s1aRHhw4PWK4vXQrN99hSUlJkmqauXbum9PT0\nHOV9+/bX1KkztWTJ19nuu3XrZklShQpuevHFV632/dxzg9WgQUO1bNlaMTHRSk1N1aZNP1hWTGRN\nPmQ1cuQYVayYseLn22/X5ig3DEPt2nWwJB+y+v33IAUFBUqSXnjh5WzJh0zOzi4aNuyfMk1TgYEn\ndPbsGavjKO5YAQEAAAAAAADcBin3tZV98PmiHsbfJqVNu9vWt7d3M9Wr10AXLpzXTz/9mOPshAMH\n9uny5UgZhqEePXIePu3g4JDnoc+maers2TOKjAyXJKWlpd3SeA8dOqD09PT//xC6fa71HnzwIR0+\n/FuO1++9t7XV7Y0yxcbG6tChP9vd6nglWcZRoYJbnvfu2PEhOTo6KjU1VYcP/6b27e/PUadpU+sr\nGypXrmK5TkrK/7ZkPj4ttX//Xp04cUyvvPKCunfvqfbt71eNGndY+m3bNudzPnAgIwnUunUbOTo6\nWu27RYt7tXTpnyuVTpw4rsTEBBmGoYce6pTrmJydXXT//R3144/fW/09lKS77/a0+vqhQwcs1w0b\nNlJiYqLVevfc42lZYXL06GE1anRXruMprkhAAAAAAAAAALfB9SmfSIYhxx3bS/8ZEB0f0vWPpt3W\n+zz++BOaM+dT7d27R7GxsZZvn0vSpk3fS5IaNrzrpnvlX716RQcP7tf58+cUGhqi0NAQBQefy/aB\neNbDkwsjMjLCcl2rVp1c69Wv3yDPfkzT1NGjhxUUdFIXL15UWFiILlwIVkREeI56typzzPXq5Ty8\nOytHR0d5eNSyOo5MlSrlXPEhSU5OfyYB0tPzP+a+fQfol18CdOpUkAIDTygw8MT/j7WB2rZtrwce\n6KgWLe7NsR3UlSuRkqQ6derm+16ZSajM/vNSr159SRkrUFJSUnIkOSpVqmS1XVjYn6s/Bg3qd9Mx\nGYaR7c9USUICAgAAAAAAALgNTLeKt+VMhLKqW7fu+uKLz5Wamip//6168smnJUmJiYnasWN7rodP\nZ7pxI0nTp0/Vjz9+b1mdkMnZ2VmtW7dRcnKyjh49fMtjvX79uiTJ3t7e6nZPmaxtvZNp375fNXXq\nZIWHh0lStvHWqlVHrVvfp/Xrv7nlsWaKj4+XJJUrV/6mdV1cMrYVSkxMsFqenwOvC6JcuXKaM2eh\nVq3y08aN3ykk5KKkjMPDg4PPadUqP9WqVVv/+tc7atXqPklSenq64uPjZRhGvs7AyJT5HDLum/ez\nyHwOUsazcHR0z1bu5OR803v8NWmS+7iu56tecUMCAgAAAAAAAECxV7lyFbVv/4B27gzQTz9tsiQg\ntm/fpqSkJDk5Oalr1265tn/nnTe1b98eGYahJk281bZtezVqdJfq1WugunXryc7OTp9/PtMmCQg3\nt4zVGWlpaUpNTc31A/mUlGSrrx85ckhvvjlK6enpqlDBTb6+D8vLq7Hq12+ohg0bqWJFdyUmJto0\nAZF5VkFuSYWsEhIyPkDP+gH87ebo6KiBA5/XwIHP6+LFC9q371cdOLBPv/22X4mJiQoNDdGbb47S\nggXL1KBBQ9nZ2cnR0UmpqSkF2u4pa9LhZs8iIeHP8oI8i8yEiGEYCggo3WfFkIAAAAAAAAAAUCL0\n6PGkdu4M0LFjRxQZGaEaNe7Qpk0bZRiGfH07yc3NzWq73347YEk+DBgwSK+8MtxqvWvXYmwyzjvv\nrGm5vnDhvBo2tL53f9ateLL64ovZSktLk7t7JS1evFzVq9e4bWPNlDnm4ODgPOslJydbxp31ff6d\n6tSpqzp16uqZZ/oqJSVFa9as1OzZM5WSkqL167/RqFFjJUk1atyhsLCMbbbyMmfOLNWoUUNt2rTP\n9p6Cg8/luX3T+fN/SMrYcsrJySnf47/jjjslZWydFR4erjvvvDPfbUsau6IeAAAAAAAAAADkR7t2\nHVSlSlWZpqmAAH9FR0dbDgDu3j3n4dOZjh07Yrnu2fMpq3XS09MtBzvf6pkKrVvfZzkPYMeO7bnW\n+/XX3VZfP3ny+P8fYN3BavJBkg4c+POb8znPU8jftj5ZNW/eUpJ0/XqcDh7cn2u9HTv8LYdeN2vW\nvMD3Kaj4+OsaNepVPfXU4/rhhw05yh0dHdW//z8siYLMcx8kqXlzH5mmqd9+O5DrQd1BQYHy81uq\nmTM/UXDwOXl6ellWM/j7b8t1XDduJGnPnl0yDEPe3gV7Dj4+91qud+7cnmu9gwf3q3Pn+zVwYG/t\n3LmjQPcoLkhAAAAAAAAAACgR7O3t9dhj3WWapnbs8NeOHf5KT09XzZoelr3/c2uX6fz5c1brzJ37\nmeW8hdTU1FsaZ/nyrvL17STTNPX118stZxZkdfjwbwoI+Nlqezu7jI9tg4Otj/XSpTDNnz/H8uvU\n1JRs5Vnfb0pK/t6Lr+/DcnevJNM09emnn1g9cyA6Okpz534mSapWrbratbs/X33fClfXCgoPv6Sr\nV69o3bo1Vn9vYmJidPlyRuLBw6O25fXHH3/i/8ujtWzZYqv9L1w4V5Lk5uamNm3ay8HBQd26ZfwZ\n27p1sw4c2Ge13axZ0xUXFytJeZ49Yo2PTwvVq9dApmnqyy8XKjz8Uo46SUlJmj37UyUnJysiIlyN\nG+d9uHpxRQICAAAAAAAAQImRudLh6NHD+u67dTIMQz16PJlnmzZt2knKWNnw8ccfaNu2Lbpy5bKu\nXLmsPXt2acyY17VixbJsBwInJibe0jhfe22UXF0rKD7+ul59dZh++GGDoqKuKjIyQqtWrdCbb47O\n9QDiNm3ayTRN/f57kD74YILOnj2j2NhrOnfuDy1b9qWGDn1O0dHRlvZZzyKQJHf3SpZrf/+fFBcX\nZzkYOzfOzs4aOXKMJOmPP87qpZcGy99/q6KjoxQVdVVbtvyol14aooiIcNnZ2enddyfY/LDp3PTv\n/5xM01RQ0Em98cZw7d+/V1euXNHly5HatesXvfHGa0pKSpKDg0O2FS4tWtyrTp0ekWmaWrhwnqZN\nm6yzZ8/o2rUYHT9+TOPGjdavv+6WYRh68cV/WrZReuGFl1W9eg2lp6dr3LjRWrx4vi5evKDY2Fgd\nP35M77zzL61f/40Mw9Cjjz6u9u0LnogZM2ac7OzsdO1ajF56abC+/XatIiLCFR0dpT17dmnEiJd0\n6lSQDMPQoEEvqGrVajZ7nn8nzoAAAAAAAAAAUGLUrVtPzZr56NixIzp1Kkj29vbq1q1Hnm3uucdL\nffsO0OrVKxQVdVUTJrybrdwwDLm7u+vRR7tr1So/SVJIyAXdfbdnocdZrVo1zZgxW+PGjVJ0dLQm\nT/5vtnIXl3IaNuwVzZv3eY62r702SidOHFdMTLQ2bdqoTZs25hivr28nhYZe1OnTpxQSciFbeYUK\nFXT33ffozJnTWrt2ldauXaW2bdtr2rRP8xxzly6PKT7+umbO/EQXL17Qf/7zdo77urpW0Ntvj89z\nxYmtPfnk0woKOqmNG7/T4cO/6dChgznG5ezsrHfemaDatetkK3v77feUlJSxXdL69d/kOLg781yQ\nXr16W16rVKmSZsz4XG+++YbCwkK0aNEXWrToixztunfvqdGj3yzUe2rZspX++9/Jev/9CYqJidYn\nn3yUo3/DMPT00301aNALhbpHcUACAgAAAAAAAECJ0qPHkzp+/KgkqW3b9qpWrfpN24wYMVpNmjTV\n+vXf6PTpU0pMTFD58q6qVau22re/X0891VvOzs5av36tkpOTFRDgny0BkfmBcG6slXl5NdaSJSu1\nevUK7dwZoLCwUJUvX14tW7bWCy+8qKtXr1rtt3btOlq0aLmWLVukvXv3KDIyUoYhValSTZ6enurR\no5fateug+fPn6MyZ0/rttwNKSIhX+fKulj4++GCqZsyYqqNHjyg1NUVJSUk3Ha8k9erVW/fd106r\nV6/Q/v17FRkZKQcHB9Ws6aGOHR9Sjx69VK2a9W/j3+wZ5beONePG/VsPPviQNm5cr8DAk4qJiZGj\no4Nq1LhDbdq0V+/e/VSzpkeOdi4uLpoyZboCAn7Wxo0bFBR0Utevx6lCBTc1b+6j3r2fVYsW9+Zo\nV7dufS1d+rXWr/9GAQE/69y5s0pKSlL16jXUtKm3evZ8Wj4+LW/pPfr6dpK3d3OtWbNSe/fuVlhY\nqJKTk1WpUmU1a+ajXr2eUcuWrQr8rIoTw7zVE1VQ7F2+HFfUQyjVqlRxlb29ndLS0hUVFV/UwwFg\nI8Q2UHoR30DpRXwDpROxDZRexHfxVL26m8364gwIAAAAAAAAAABgcyQgAAAAAAAAAACAzZGAAAAA\nAAAAAAAANkcCAgAAAAAAAAAA2BwJCAAAAAAAAAAAYHMkIAAAAAAAAAAAgM2RgAAAAAAAAAAAADZH\nAgIAAAAAAAAAANgcCQgAAAAAAAAAAGBzJCAAAAAAAAAAAIDNkYAAAAAAAAAAAAA2RwICAAAAAAAA\nAADYHAkIAAAAAAAAAABgcyQgAAAAAAAAAACAzZGAAAAAAAAAAAAANkcCAgAAAAAAAAAA2BwJCAAA\nAAAAAAAAYHMORT2A4uTUqVOaP3++9u3bp6tXr6pSpUry9vbWwIED9eCDDxa7fgEAAAAAAAAAKK4M\n0zTNoh5EcbBt2zaNHDlSqampMgzD8nrm4xk0aJDeeeedYtNvQVy+HHdb+y/rqlRxlb29ndLS0hUV\nFV/UwwFgI8Q2UHoR30DpRXwDpROxDZRexHfxVL26m836YgsmSYGBgRozZozS0tLk4+OjZcuW6ddf\nf9WaNWvUpUsXSdKyZcvk5+dXLPoFAAAAAAAAAKC4IwEhacaMGUpKSlLdunX15ZdfqnXr1nJ3d1fT\npk01a9YsPfbYYzJNU7NmzVJCQkKR9wsAAAAAAAAAQHFX5hMQf/zxhwICAmQYhv75z3+qXLlyOeq8\n9dZbsrOzU0xMjLZs2VKk/QIAAAAAAAAAUBKU+QTEjh07JEmGYeihhx6yWufOO+9U48aNJWWc6VCU\n/QIAAAAAAAAAUBKU+QREUFCQJMnDw0OVKlXKtV6TJk1kmqZOnDhRpP0CAAAAAAAAAFASlPkERGho\nqCSpdu3aedbz8PCQJIWHhys9Pb3I+gUAAAAAAAAAoCQo8wmI6OhoGYahihUr5lnPzc1NkmSapmJj\nY4usXwAAAAAAAAAASoIyn4C4ceOGJMnFxSXPes7OzjnaFEW/AAAAAAAAAACUBGU+AWFnd3sewe3q\nFwAAAAAAAACAksChqAdQ1MqXLy/p5qsPspbfbFXD7ey3MCpXLi/DMG5L35Ds7AzL/6tUcS3i0QCw\nFWIbKL2Ib6D0Ir6B0onYBkov4rv0K/MJCDc3N5mmqevXr+dZL/N8Bnt7e7m7uxdZv4Xh4GB/W/pF\ndoZhyN6eRA9Q2hDbQOlFfAOlF/ENlE7ENlB6Ed+lV5nfJ6h+/fqSpNDQ0DzrXbp0SZJUo0aNIu0X\nAAAAAAAAAICSoMwnIDw9PSVJISEhio+Pz7XeiRMnZBiGmjRpUqT9AgAAAAAAAABQEpT5BETHjh0l\nSWlpaQoICLBaJzw8XEFBQZKkBx98sEj7BQAAAAAAAACgJCjzCYg6deqoVatWMk1Tn376qdUzGyZP\nnqz09HRVrlxZTz75ZJH2CwAAAAAAAABASVDmExCS9Pbbb8vOzk7nz5/XgAEDtGvXLkVHR+vkyZMa\nPny4Nm/eLMMwNGLECLm4uFjaRURE6LHHHlO3bt00ffp0m/ULAAAAAAAAAEBJZ5imaRb1IIqDdevW\nafz48UpLS9NfH4lhGBoyZIjefPPNbK+Hhoaqc+fOMgxDvXr10uTJk23SLwAAAAAAAAAAJZ1DUQ+g\nuHjqqafk7e2thQsXau/evbpy5YrKly+vZs2aaeDAgXr44YettjMMI9v/bdUvAAAAAAAAAAAlGSsg\nAAAAAAAAAACAzXEGBAAAAAAAAAAAsDkSEAAAAAAAAAAAwOZIQAAAAAAAAAAAAJsjAQEAAAAAAAAA\nAGyOBAQAAAAAAAAAALA5EhAAAAAAAAAAAMDmSEAAAAAAAAAAAACbIwEBAAAAAAAAAABsjgQEAAAA\nAAAAAACwORIQAAAAAAAAAADA5khAAAAAAAAAAAAAm3Mo6gEAt8P777+vr7766qb1xo8fr4EDB2Z7\nLTExUYsWLdLmzZt14cIF2dvbq169eurWrZsGDRokZ2fnPPv8+eef5efnp2PHjikhIUHVq1dXhw4d\nNGTIEDVq1CjPtqGhofriiy+0a9cuRUREqEKFCvL09FSfPn3UvXv3m79xoJTKjOmPPvpIvXr1yrNu\nSY3h1NRU+fn5acOGDTpz5owkqVatWnrkkUc0ZMgQubu759keKKnyG9+BgYF66qmnbtqft7e31qxZ\nY7WM+AZur4CAAK1du1ZHjhxRVFSUnJycVK9ePfn6+uq5555TlSpVrLZj7gaKv8LEN3M3UPxt2bJF\nq1ev1rFjxxQfH69q1aqpZcuW6tu3r9q1a5drO+ZuFIRhmqZZ1IMAbG3AgAE6dOhQnnUMw9C7776b\nLQERExOjAQMG6I8//pBhGNnqm6aphg0basmSJapevbrVPqdOnaqFCxdabevk5KQPP/xQPXr0sNr2\n6NGjGjJkiOLj462279q1q2bMmCE7OxYuoWzZunWrXn/9dZmmqcmTJ+f5AWVJjeHk5GQNHTpU+/fv\nt9q2Ro0aWrRoke66665c3ztQEhUkvlevXq3x48fniJG/8vb21urVq3O8TnwDt09aWprGjRun77//\n3mqMmqapqlWr6vPPP1eLFi2ylTF3A8XbrcQ3czdQfKWmpmrs2LHatGmT1T/nktSvXz9NnDgxR1vm\nbhSYCZQy6enpZsuWLU0vLy/z66+/NhMSEnL9LzU1NVu7fv36mZ6enmarVq3Mr7/+2oyMjDQvXbpk\nLly40PTx8TG9vLzMvn37Wr3vihUrTE9PT9PLy8t86623zFOnTpnR0dHmL7/8Yj7xxBOmp6en2axZ\nMzMwMDBH2/DwcLNdu3aml5eX+dhjj5kBAQFmdHS0eebMGXP8+PGml5eX6eXlZX788ce37bkBxdG2\nbdtMb29vSwysW7cu17olOYZHjx5tenp6mt7e3ua8efPM0NBQ8/Lly+bq1avNNm3amJ6enmbnzp3N\nxMTEwj1IoBgqSHybpmlOmDDB9PT0NAcMGGAmJibmOrffuHEjR1viG7i9PvroI0uMDR8+3Dx06JAZ\nExNjnj592lywYIHZsmVL09PT02zbtq0ZERFhacfcDRR/hY1v02TuBoqzyZMnW2Js9OjR5pEjR8yr\nV6+aR48eNUeNGmWJk7lz52Zrx9yNwiABgVLnzJkzlh9mp06dyne7H3/80dJu586dOcq3b99uKf/+\n+++zlSUmJprt27c3vby8zDfeeCNH29jYWLNr166ml5eX+cILL+Qonzhxounp6Wm2adPGvHLlSo7y\nKVOmWH5IhoaG5vs9ASVVenq6OXPmTLNx48aml5eXJfby+oCypMbwsWPHLONauXJljrYnT560fEg7\nb968XN8/UFIUJr5N0zT79Oljenl5mR999FGB7kd8A7dXRESE2bRpU9PLy8t88803rdY5duyYpc6k\nSZMsrzN3A8XbrcS3aTJ3A8VV1tgeM2aM1Tr//Oc/LXGUNUnI3I3CYC8XlDonT56UJJUrV65Ay6YW\nL14swzDUunVr3X///TnKfX191aFDB5mmqVWrVmUrW79+vaKioiRJo0ePztHWzc1Nw4cPl2ma2r17\nt8LCwixlcXFxWrt2rQzD0HPPPaeqVavmaD98+HBVrFhRqampWrduXb7fE1AS/fLLL+rZs6dmz54t\n0zTVtGnTfLUrqTG8aNEiSVLt2rXVp0+fHG0bN26sXr16yTRNq0vTgZKksPGdnp6uU6dOSZKaNWtW\noHsS38DttXXrVqWmpkqSRo0aZbWOt7e3HnnkEZmmqe3bt1teZ+4GirdbiW/mbqD48vf3V1pamgzD\n0Kuvvmq1Ts+ePSVJsbGxOnfunOV15m4UBgkIlDqZCYimTZvedK/JTNeuXdPRo0clSZ07d861XmbZ\ngQMHFBcXZ3k9ICBAknTPPfeodu3aVts+/PDDsre3lyRt27bN8vrevXt148aNPO9dvnx5tWvXTqZp\nZmsLlEYvvviizpw5I0dHR40YMULTp0+/aZuSHMM7d+6UYRh66KGHcv2ZldlvSEiIfv/991zfH1Dc\nFSa+JenMmTNKSkqSJDVv3rxA9yS+gdsrMjJS5cqVU7Vq1VSzZs1c69WrV89SX2LuBkqCwsa3xNwN\nFGf9+vXT9u3btXjxYjVs2PCm9R0cHCQxd6PwSECg1Dl+/LgMw1Djxo21evVq/eMf/1Dr1q3l4+Oj\nxx9/XJ988oliYmKytQkKCrIcsuPt7Z1r340bN5aU8W2OzERHZnvDMPL8JmeFChUsP2BPnDhheT0w\nMFCSZG9vLy8vr1zbN2nSRJJ06tQpy7dQgNLIzs5OXbt21XfffadXX301Xwevl9QYDgkJUWxsrCTl\nee/Mcf/13kBJU5j4lv78c1+pUiVdvXpVY8eOla+vr7y9vfXAAw9o5MiROnTokNW2xDdwe40aNUqH\nDh3Spk2b8qwXHBwsSapYsaIk5m6gJChsfEvM3UBxd8cdd6ht27ZWy1JTU7V8+XJJUq1atdSgQQNJ\nzN0oPBIQKHUyfyitWLFC48eP18GDBxUfH6/k5GSdO3dO8+fP1+OPP64jR45Y2oSGhlquc8vCShk/\neDOFhIRIyviBGh4eftO2kuTh4SHTNC1ts967Zs2aea7Y8PDwkCSlpaXp0qVLed4HKMl+/PFHzZw5\n0/KXnPwoqTGc33HXqFHD8q2TrPcGSprCxLf05z8Arl+/rn79+mnjxo2KjIxUWlqarl69qs2bN6t/\n//6aOXNmtnbEN/D3cXV1zbUsMjJS/v7+li0bJOZuoCTJb3y3atXK8jpzN1CyJCYmKjg4WOvWrdMz\nzzyj/fv3y8nJSRMnTrR8aYi5G4XlUNQDAGwpODhY169fl5Txw6Z///7q06ePatWqpcuXL2vDhg1a\nuHChoqKi9NJLL+mbb75RrVq1FB0dbekj67c2/qpChQqW68zsaUxMjNLT02UYhtzd3fMcn5ubm6SM\nZWuZMu+d132zts16b6A0ylzCXRAlNYazjjuvexuGIVdXV8XGxhL/KNEKE9/Snx9ipKamytvbW6++\n+qqaN2+u9PR07d27V59++qlCQkI0d+5cVa5cWYMGDZJEfAPFxfjx43Xjxg0ZhqGBAwdKYu4GSgtr\n8S0xdwMlzbBhw3Tw4EHLrz08PDRjxoxsW6gxd6OwWAGBUiUiIkI1a9aUvb29PvroI7333ntq0qSJ\n3N3dddddd2n06NGW/aZjY2P18ccfS5JlHzlJcnFxybX/rGWZbZKTky2vOTs75zm+zPKsbTL7yeu+\nud0bQIaSGsP5HXfWcuIfZVFqaqpcXFzUsWNHff311+rUqZOqVaumGjVq6IknntCqVatUu3Ztmaap\n6dOnWw63I76Bovfhhx8qICBAhmHoiSee0H333SeJuRsoDf4a323atLGUMXcDJculS5dkGIblv7Cw\nML333nvZkhLM3SgsEhAoVdq0aSN/f38dOXJEPXv2tFqnS5cueuihh2SaxF5fzAAAGsVJREFUprZu\n3aq4uDjLATeFkd/9q3NzK/cGkKGkxjDxD+TP6tWrdfjwYc2ZM8eyLDqrypUr61//+pckKSkpST/8\n8IMk4hsoapMnT9bSpUtlGIY8PT01ceJESxlzN1Cy5RXfEnM3UNIsWrRIR48e1e7du/X++++rcuXK\nCgwM1LBhw3T48GFJzN0oPBIQKJWs/QUnq8yT7dPT03X8+HGVK1fOUpZXljMpKclynZkVLV++fL7a\nZi3Pmu3NvPfN2lq7N4AMJTWG8zvurO1v9m0RoDTL6x8uvr6+lvk/85wn4hsoGikpKfrXv/6lJUuW\nyDAM3XXXXVq4cGG2uGDuBkqm/MR3VszdQMlQv359OTo6qnLlynrmmWe0dOlSOTs7KykpybJ7CHM3\nCosEBMqkzENpJCkqKirbHnJxcXG5tstaVqlSJUkZB3JlZlMzz5/ITeYecpUrV7a8lrk/XV73zdr2\nr+0BqMTGcH7HbZqm4uPjc9wbwJ+cnZ0t8ZG5jQPxDfz9rl27piFDhmjDhg0yDEPe3t5aunSpqlat\nmq0eczdQ8uQ3vvOLuRsovu6++2717NlTpmnq0KFDiomJYe5GoZGAQJmUkpJiuS5Xrpzq169v+XVY\nWFiu7bKWZSYxDMNQnTp1JEmhoaF53jdzT72sCZAGDRpIksLDw2/aVspYOla9evU86wJlTUmN4fyO\nOzIyUqmpqdnGDSCnzPk98xtWxDfw97pw4YL69u2rAwcOyDAMdezYUUuXLrX6j3jmbqBkKUh8FwRz\nN1B8NW3a1HIdEhLC3I1CIwGBUmXs2LFq166dunTpkme9M2fOWK7r16+vu+66S4ZhSJJOnjyZa7vM\nMsMw5OXlZXn9nnvukWmaCgwMzLXt9evXFRISIklq3LhxtrZSxuE6Z8+evem977777ptuMQWUNSU1\nhqtXr275Rkh+xv3XewNlwU8//aSOHTuqWbNm2r9/f671oqKiFBMTIyn7PzKIb+Dvcfr0aT377LMK\nDg6WYRjq27ev5syZk+u2LMzdQMlR0Phm7gaKty+++EIDBw7UiBEj8qz31+2MmLtRWCQgUKpUrFhR\nMTExCgkJyfMH0saNGyVJtWrVUsOGDVWhQgW1atVKpmnq559/zrVdZlnz5s2zLeHy9fWVJAUGBioi\nIiLXtmlpaZKkBx54wPJ6mzZtLH9x27Ztm9W2iYmJ+vXXXy3fNAGQXUmOYV9fX5mmqe3bt9903NWr\nV8/2FzigLLjzzjst30YKCAjItd53331nuc4aZ8Q3cPtdvHhRQ4YMUVRUlAzD0KhRozRx4sQ8935n\n7gZKhsLEN3M3ULxdvnxZBw8elL+/vy5fvpxrvV9++UVSxvZJ9evXZ+5GoZGAQKnyxBNPWK4//PBD\nq3W++OILBQYGyjAMDR061PJ6r169JEm7du2y+pek7du3a/fu3TIMQ0OGDMlW1rVrV5UvX15paWma\nMmVKjrZxcXH6/PPPJWX80GvYsKGlrHz58urSpYtM09TixYutLif79NNPFRsbK0dHRw0YMCCvRwCU\nWSU1hjPH/ccff2jFihU52p48eVLffvutDMPQ4MGDb/IUgNKnWbNmatCggUzT1PLlyxUcHJyjztmz\nZy0x2qxZM913332WMuIbuL1SU1M1atQoXblyRYZh6J133tHLL7+cr7bM3UDxVtj4Zu4GirfMz87S\n0tL0ySefWK2zceNG7dq1S4Zh6KmnnrKsJmDuRmHYT5gwYUJRDwKwlZo1a+rcuXM6deqULl68qP37\n96t27doqV66cgoODNXPmTC1cuFCGYaht27YaP368pa2Xl5cl+7t161Y5OzvLw8ND8fHxWrVqlSZO\nnKi0tDT5+PjorbfeynZfZ2dnOTs7a+fOnTp9+rROnTql+vXry8HBQQcPHtQbb7yhP/74Qy4uLvr4\n449znOHQrFkzrVy5UnFxcdqyZYtq1qypypUrKywsTDNmzNDy5cstP7y7du36tzxLoLiIi4vT0qVL\nZRiGHnnkkVy/iVBSY7hOnTo6efKkzp07p507dyo5OVm1a9dWSkqKfvjhB7355ptKSEhQ3bp19f77\n78vR0dG2DxgoQvmN73r16mnjxo2WuKhUqZIqVaqkhIQEbdiwQePGjdO1a9fk6uqqOXPmZDsMk/gG\nbi8/Pz+tXbtWhmGoW7duGj58uFJSUvL8L/PPOnM3ULzdSnwzdwPF1x133KGQkBAFBQUpKChIJ06c\nkIeHh1xcXBQaGqoFCxZo2rRpkjJiedq0aXJ2dpbE3I3CMUzTNIt6EIAt3bhxQ6NHj5a/v7+kjFPs\nszIMQx06dNCsWbMsB11lCgsL0+DBg3Xx4kWr7Ro2bKivvvrK6kFbpmnqvffe0+rVq622tbe318yZ\nM9W5c2er4965c6dGjBihpKQkq+27deum//3vf/l7CEApEhoaqs6dO8swDE2ePNnyzQVrSmoMx8bG\natiwYTp27JjVttWqVZOfn5/l0C6gtChIfH/zzTeaMGGCUlJSrMZJ1apVNXPmTLVq1SpHW+IbuH26\ndOmiixcvFqhNUFCQ5Zq5Gyi+bjW+mbuB4is5OVljx47VTz/9JMn6Z2eNGzfWZ599luNAZuZuFBQr\nIFDqODg4qHv37vL09FRCQoLi4uKUmpqqKlWqqFWrVho5cqTGjh1rNZvp5uam3r17y9nZWdeuXVNC\nQoLs7e3VsGFDDRw4UJMnT5abm5vV+xqGoYcfflhNmzZVXFyc4uLilJKSomrVqqlz58766KOPsi0r\n/au6devqySef1I0bN3Tt2jUlJSWpXLlyat68uV5//XWNHDnSZs8IKEni4uK0bNkyGYahzp0757kX\nY0mNYWdnZz399NOqXLmyrl27pvj4eEkZ39J4+umnNXXqVN155535fGJAyVGQ+G7cuLG6deumtLQ0\nxcXF6caNG3JxcVGjRo3Ur18/TZkyRQ0aNLDalvgGbo/o6GhNnz5dhmHk+z87Ozu99tprlj6Yu4Hi\nyRbxzdwNFF/29vbq1q2bGjdurPj4eEuMubu7695779Urr7yi//znP3J3d8/RlrkbBcUKCAAAAAAA\nAAAAYHMcQg0AAAAAAAAAAGyOBAQAAAAAAAAAALA5EhAAAAAAAAAAAMDmSEAAAAAAAAAAAACbIwEB\nAAAAAAAAAABsjgQEAAAAAAAAAACwORIQAAAAAAAAAADA5khAAAAAAAAAAAAAmyMBAQAAAAAAAAAA\nbI4EBAAAAAAAAAAAsDkSEAAAAAAAAAAAwOZIQAAAAAAAAAAAAJsjAQEAAAAAAAAAAGyOBAQAAAAA\nAAAAALA5EhAAAAAAAAAAAMDmSEAAAAAAAAAAAACbIwEBAAAAAAAAAABsjgQEAAAAAAAAAACwORIQ\nAAAAAAAAAADA5hyKegAAAAAAcrdv3z4NGjTolvsJCgqywWgK5sKFC+rataskqU+fPpo0aZJN+9+z\nZ4+GDBkiSRo1apReeeUVm/ZfEvTv31+HDh2Sg4ODjh8/XtTDAQAAALIhAQEAAAAUc4ZhFGn7W3W7\n71/U768oleX3DgAAgOKPBAQAAABQjN1999367LPPci1/7bXXZBiGqlSpov/+979/48jyJ/MD8tv1\nQTkfwPMMAAAAUHwZpmmaRT0IAAAAAIXj5eUlwzDk4eGhbdu2FfVwAAAAAMCCQ6gBAAAAAAAAAIDN\nkYAAAAAAAAAAAAA2xxkQAAAAQBmyevVqjR8/XoZhaOfOnTp69KhmzJihc+fOyc3NTU2aNNGHH36o\n6tWrW9qcOnVK69at0759+3Tp0iXFxsaqfPnyql69ulq1aqUBAwbIy8srx70uXLigrl27SpL69Omj\nSZMmWcr27NmjIUOGSJJWrVqlZs2aae3atVq/fr3OnDmjhIQE3XnnnfL19dXQoUN1xx135Og/ax+j\nRo3SK6+8kuv7dHNzk5+fn3744QedP39eKSkpql27th555BENGTJEFStWzPO5BQQEaOXKlTpy5Iiu\nXbum6tWrq0OHDho2bJgaNGigLl266OLFizneZ37FxMToq6++0o4dO3T27FklJyerUqVKuueee9Sp\nUyf16dNHTk5OOdr1799fhw4dkoODg44fP255fezYsfr+++8LNAY/Pz/de++9OV4/evSoVq5cqf37\n9ysyMlKOjo6qXbu2fH19NWjQIFWpUqXA7xcAAABlAwkIAAAAoIzatm2bJkyYoMxj4aKionT69GlL\n8sE0TU2aNEkrVqyQaZrZDjuOi4tTbGyszp49q9WrV2vs2LEaOnSo1fvkdUiyYRhKSEjQ4MGDtXfv\n3mx1g4ODtXTpUq1evVrz589X69atC9y/JF2+fFlDhgzRqVOnstU9ffq0Tp8+rVWrVmnp0qVq1KiR\n1fYTJ07UihUrst0rPDxca9eu1caNGzVlyhQZhlHow6BPnDihYcOGKTo6OlsfV65c0eXLl7Vr1y4t\nWrRIX375perUqZOv916Y8fy1fnp6uj744AP5+fll+/2/ceOGgoKCFBgYqK+++koff/yxOnXqVKB7\nAQAAoGwgAQEAAACUUR988IGcnZ01aNAg3X333Tpx4oQqVapkKf/kk0/k5+cnwzBUrVo1PfXUU2rQ\noIGcnJwUEhKijRs36syZMzJNU//73//0wAMPyNPTs8DjmDhxos6dO6d69erpmWeeUZ06dRQeHq6v\nv/5aFy5cUFJSksaOHastW7ZYXQVwM6NHj9b58+fVuHFjPfnkk7rjjjt0/vx5+fn56cqVK4qKitK4\nceO0Zs2aHG0nT56sFStWyDAMVaxYUc8++6w8PT0VHR2t9evX69ixYxozZowcHR0LPC5JSk5O1ogR\nIxQTEyMHBwc98cQTuu++++Tq6qpLly5p/fr1CgoKUlhYmEaOHKlvvvkmX/0OGTJEjz32WJ51Nm3a\npA0bNsgwDLVu3Vo+Pj7Zyt99912tW7dOhmGoatWq6t27tzw9PZWcnKwDBw5o/fr1un79ul5//XXN\nmzdP999/f6GeAQAAAEovEhAAAABAGWSappKTkzVr1iw98sgjkqQePXpYyq9cuaIlS5ZIkurWras1\na9bIzc0tWx8vv/yyxo0bp++++07p6enauHFjoRIQ58+fV6dOnTRjxoxsCYa+ffuqb9++Onv2rCIi\nIvTLL7+oc+fOheq/X79+eu+997J9y/+ZZ55Rr169FBUVpRMnTigoKCjbVlKnTp3SV199JcMwVLdu\nXS1dujTbVlADBw7Uhx9+qKVLlyo1NbVQKyD8/f0VFhYmwzA0duxYDR48OFv5888/r5deekm//PKL\nAgMDdfDgQbVq1eqm/TZp0kRNmjTJtfzEiRP66aefJEk1atTQ9OnTZWf35xGBW7ZssSQfWrdurdmz\nZ2f7/e/Vq5f+8Y9/aMiQIYqJidG4ceO0bds2OTs7F/AJAAAAoDTjEGoAAACgDDIMQw0bNrQkH/7K\n39/f8qH6a6+9liP5kNnHyy+/bPn1+fPnCzwO0zTl5OSkyZMn51jd4Orqqueff97y62PHjhWq/+rV\nq1vOg8iqRo0a6tOnT679z5s3T2lpaZKkadOmWT2H4u23386xcqAgzp07Z7n29fXNUW4Yhl599VXV\nrl1bHTp0UFJSUqHvlSkqKkrDhw9XUlKSHB0dNWPGDFWrVi1bnfnz50vK+D349NNPrf7+e3l5acyY\nMTJNU1evXtW6detueWwAAAAoXUhAAAAAAGVUXt+kf/rpp7V582bNnz9fXbp0ybVe7dq1LdeJiYkF\nHoNhGGrTpo3c3d2tlmddkRAXF1eo/jt16iR7e3ur5VlXbGTtPz09XTt37pRhGGrRooWaNWuWa/9/\nXbVQEFm3vFq8eLEl4ZFVy5YttXXrVi1cuPCWtzlKS0vTyJEjdenSJRmGoXHjxqlly5bZ6oSFhenY\nsWMyDEO+vr6qXLlyrv317NlTDg4ZC+u3b99+S2MDAABA6cMWTAAAAEAZ1bBhw1zL7O3tVbduXdWt\nW9dqeUREhI4dO6Y9e/ZYXktPTy/UOHI7/FmSKlSoYLlOSUmxef9Zv9mfmppquf7999917do1S4Ik\nL23bti3UuCSpU6dO+uCDD5SSkqJVq1Zp586d6tKli3x9fdW6detCnXmRl8mTJ2v//v0yDEPdu3fX\nP/7xjxx1jhw5YrlOTU3V1q1b8+yzWrVqCg8P1/Hjx206VgAAAJR8JCAAAACAMsratjrW/Pbbb9q9\ne7fOnj2r4OBgXbhwQdevX89RzzTNQo0ja5LhrzK/XX8r/ef1PrP2nzWBEhkZabn28PDIs/8qVarI\n1dVVCQkJBR5bjRo1NGHCBL333ntKS0tTWFiYlixZoiVLlqhcuXJq166dunTpoq5du+b5nPLjm2++\nsZxpcc899+j999+3Wi8iIsJyvXnzZm3evDlf/cfExNzS+AAAAFD6kIAAAAAAyqibfbv+7Nmzeuut\nt7KdjZB5joJhGKpVq5Y6duwoPz+/WxpH1iTA7ZDb9kt5iY6Otlzn52DlcuXKFSoBIWUchu3p6al5\n8+YpICDAstIjKSlJ/v7+8vf31/vvv6833njD6oqF/Dh69KgmTJggKSMh89lnn8nFxcVq3azJpYIc\nrJ2enq6kpKRc+wUAAEDZQwICAAAAQA4REREaOHCgZRuiqlWrqkOHDvLy8lKjRo3UuHFj1ahRQ8nJ\nybecgCiOsn6Inp+zLQpz/kVW3t7emjVrluLj47Vz507t2rVLu3btUlhYmCQpISFBH3zwgVxcXNS7\nd+8C9X316lWNGDFCycnJsrOz05QpU1SnTp1c65crV85yPWnSpALfDwAAAMhEAgIAAABADjNmzFBM\nTIwMw9DAgQP19ttvW11JUJiDoUuCO++803IdGhqaZ93Y2FjFx8cXaLVAblxdXfXoo4/q0UcflZRx\nFsWCBQu0YcMGSdLs2bMLlBBITU3ViBEjFBERIcMw9NJLL+nhhx/Os03VqlUt15cvXy7EuwAAAAAy\n2BX1AAAAAAAUPwEBAZKk8uXLa9y4cbluYxQYGGi5LuwZDcVRkyZN5OjoKCnjDIy8HDx4sND3CQgI\n0Lx58zRr1iyr5Z6enpo6daqaNGki0zR16dIlq+dv5GbSpEn67bffZBiG7r//fo0aNeqmbZo1a2a5\n3rdvX551k5OTNXLkSE2aNEkrVqzI97gAAABQNpCAAAAAAJBD5tZLDg4Olg/irfnyyy8t16mpqX/D\nyP4eTk5Oevjhh2Wapg4fPqygoKBc63711VeFvs+CBQs0ffp0zZs3L89DnN3d3SVlnGeR3zMWVq9e\nrZUrV0rKOEj7k08+yVe7Ro0aqX79+jJNU3v37tXJkydzrbtu3Tpt3rxZy5cv16+//pqv/gEAAFB2\nkIAAAAAAkIOHh4dM01RsbKy2bNmSozwtLU3vv/++du7cKSlj9cONGzf+7mHeVkOHDpVhGDJNU2PG\njLG6HdHs2bO1a9euQm+/9Nhjj0nKeJ7jx49XWlpajjqHDh3SgQMHZBiGfHx88nVo96FDh/Tf//5X\nhmGoXLlymj17tiWJkR/Dhg2TlPH7OnLkSF28eDFHnRMnTmjKlCmSMg6rfuGFF/LdPwAAAMoGzoAA\nAAAAkEOvXr00a9YsmaapN954Q08//bRatGghOzs7nTt3Ths2bFBYWJjlg3fTNEvdeRA+Pj4aMGCA\nli9frrNnz6pHjx569tln5enpqdjYWG3cuFH79++Xg4ODUlNTZRiG7OwK9h2v3r17a8mSJbpw4YJ+\n+uknPf744+rVq5fq1KmjhIQEHT9+XOvWrVNKSors7e01YsSIm/YZFRWl119/3bIi5fnnn1d8fLx2\n796tpKQkpaenW21XtWpVtWzZ0jKun3/+Wf7+/rp48aJ69uypp556Si1atFBKSooOHz6sdevWWd73\nwIED5ePjU6D3DgAAgNKPBAQAAABQwt2OsxdefPFFHTx4UHv27FFaWppWrVqlVatWWcozt2caPny4\njhw5YvmgOikpKd9bBJUE7777rq5du6aNGzcqNjZW8+bNs5QZhiFXV1e9/fbb+ve//y0pY+umgnB2\ndtbcuXP14osvKiwsTBcuXNDMmTOz1clcxfDee++pXbt2N+3z999/z7ZaY+7cuZo7d+5N23Xo0EGL\nFi2y/HrmzJn6z3/+o2+//VZJSUny8/OTn59ftnEZhqH+/fvr3Xffzc/bBQAAQBlDAgIAAAAowTJX\nIBRkC6DMD47z4uTkpIULF2rlypXasGGDTp8+rYSEBLm6uqp27dq677771L9/f9WrV0/Lli3T9u3b\nlZ6eri1btqhnz575Gl9+x1zYPvLzPm/Wh52dnaZNm6bu3btr1apVOn78uK5du6aqVauqY8eOeuWV\nV7JtPVWQbY4yNWzYUN9//71Wrlypn3/+WWfOnFFsbKzKly8vDw8P+fr6ql+/fvLw8Mj3+AuzJdRf\n2zg6Omry5Mnq27ev1qxZowMHDigyMlLp6emqUaOGWrVqpb59++ree+8t8L0AAABQNhjm7fi6FAAA\nAACUEQcPHtTAgQNlGIYmTZqk3r17F/WQAAAAgGKBFRAAAAAAYMWYMWOUnp4uHx8fDR48ONd6W7du\ntVw3bdr0bxgZAAAAUDIU7IQ0AAAAACgjkpKS9OOPP2ratGk6ceKE1Tp79+7VihUrJGVspdS4ceO/\nc4gAAABAscYWTAAAAABgxY4dO/TSSy9JklxcXNStWze1aNFCFStW1NWrV7Vv3z5t27ZNaWlpsre3\nl5+fn3x8fIp41AAAAEDxQQICAAAAAHKxYMECzZgxQ2lpabL2TyfDMOTu7q6pU6fqwQcfLIIRAgAA\nAMUXCQgAAAAAyMPZs2e1atUq7d27VyEhIbpx44aqVq2qWrVqqWvXrurZs6cqV65c1MMEAAAAih0S\nEAAAAAAAAAAAwOY4hBoAAAAAAAAAANgcCQgAAAAAAAAAAGBzJCAAAAAAAAAAAIDNkYAAAAAAAAAA\nAAA2RwICAAAAAAAAAADYHAkIAAAAAAAAAABgcyQgAAAAAAAAAACAzZGAAAAAAAAAAAAANkcCAgAA\nAAAAAAAA2BwJCAAAAAAAAAAAYHMkIAAAAAAAAAAAgM2RgAAAAAAAAAAAADZHAgIAAAAAAAAAANgc\nCQgAAAAAAAAAAGBzJCAAAAAAAAAAAIDNkYAAAAAAAAAAAAA2RwICAAAAAAAAAADYHAkIAAAAAAAA\nAABgc/8HRYSfvy+xRFMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11013ea58>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 535,
+       "width": 784
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Learning curve.\n",
+    "fig, ax = plt.subplots(1, 1)\n",
+    "\n",
+    "N, train_lc, val_lc = learning_curve(model, X, y, cv=2, train_sizes=np.linspace(0.1, 1.0, 5))\n",
+    "\n",
+    "ax.plot(N, np.mean(train_lc, 1), color='blue', label='Training score')\n",
+    "ax.plot(N, np.mean(val_lc, 1), color='red', label='Validation score')\n",
+    "ax.hlines(np.mean([train_lc[-1], val_lc[-1]]), N[0], N[-1], color='gray', linestyle='dashed')\n",
+    "\n",
+    "ax.set_ylim(0, 1)\n",
+    "ax.set_xlim(N[0], N[-1])\n",
+    "ax.set_xlabel('Training size')\n",
+    "ax.set_ylabel('Score')\n",
+    "ax.set_title('Learning curve')\n",
+    "ax.legend(loc='lower right')\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [conda root]",
+   "language": "python",
+   "name": "conda-root-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
In [`osm-compare`](https://github.com/mapbox/osm-compare), we have a mechanism to add interesting labels to changesets on [osmcha](http://osmcha.mapbox.com/). Ex: A [`null_island` comparator](https://github.com/mapbox/osm-compare/blob/master/comparators/null_island.js) labels a changeset as `Feature near Null Island` when a changesets has one of it's features very close to [0, 0].

In our last sync, @anandthakker and me discussed the idea of using the results from these compare functions as features to train the machine learning model. I personally think this will be :boom:! With this PR, we explore this idea.

---


- Cross validation score: `0.9`
- Classification report

```
precision           recall  f1-score   support

problematic         0.75      0.00      0.01      1731
not problematic     0.91      1.00      0.95     17488

avg / total         0.90      0.91      0.87     19219
```

- Learning curve

![index](https://cloud.githubusercontent.com/assets/2899501/24844576/4221e33e-1dc9-11e7-9b42-647cee380dc4.png)
