### PR TITLE
Get similar samples using attributes

### DIFF
--- a/notebooks/similar_samples.ipynb
+++ b/notebooks/similar_samples.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Similar samples - Gabbar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path = '../downloads/old-feature-classifier/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>changeset_id</th>\n",
+       "      <th>changeset_harmful</th>\n",
+       "      <th>changeset_features_created</th>\n",
+       "      <th>changeset_features_modified</th>\n",
+       "      <th>changeset_features_deleted</th>\n",
+       "      <th>changeset_has_imagery_used</th>\n",
+       "      <th>changeset_has_source</th>\n",
+       "      <th>changeset_comment_number_of_words</th>\n",
+       "      <th>changeset_comment_naughty_words_count</th>\n",
+       "      <th>changeset_bbox_area</th>\n",
+       "      <th>...</th>\n",
+       "      <th>railway_old</th>\n",
+       "      <th>route_old</th>\n",
+       "      <th>shop_old</th>\n",
+       "      <th>sport_old</th>\n",
+       "      <th>tourism_old</th>\n",
+       "      <th>waterway_old</th>\n",
+       "      <th>tag_values_popularity_min</th>\n",
+       "      <th>tag_values_popularity_max</th>\n",
+       "      <th>tag_values_popularity_mean</th>\n",
+       "      <th>tag_values_popularity_stddev</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>47303446</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0164</td>\n",
+       "      <td>0.5083</td>\n",
+       "      <td>0.2623</td>\n",
+       "      <td>0.2459</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>47867864</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>18</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1091029462</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.2896</td>\n",
+       "      <td>0.2896</td>\n",
+       "      <td>0.2896</td>\n",
+       "      <td>0.0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>48007382</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0043</td>\n",
+       "      <td>0.0043</td>\n",
+       "      <td>0.0043</td>\n",
+       "      <td>0.0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>48971499</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>35</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0221</td>\n",
+       "      <td>0.0221</td>\n",
+       "      <td>0.0221</td>\n",
+       "      <td>0.0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>47412284</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>448</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3255</td>\n",
+       "      <td>0.3255</td>\n",
+       "      <td>0.3255</td>\n",
+       "      <td>0.0000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 115 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   changeset_id  changeset_harmful  changeset_features_created  \\\n",
+       "0      47303446                  0                           0   \n",
+       "1      47867864                  0                           0   \n",
+       "2      48007382                  1                           0   \n",
+       "3      48971499                  1                           0   \n",
+       "4      47412284                  0                           0   \n",
+       "\n",
+       "   changeset_features_modified  changeset_features_deleted  \\\n",
+       "0                            1                           0   \n",
+       "1                            1                           0   \n",
+       "2                            1                           0   \n",
+       "3                            1                           0   \n",
+       "4                            1                           0   \n",
+       "\n",
+       "   changeset_has_imagery_used  changeset_has_source  \\\n",
+       "0                           0                     0   \n",
+       "1                           1                     0   \n",
+       "2                           1                     0   \n",
+       "3                           1                     0   \n",
+       "4                           1                     0   \n",
+       "\n",
+       "   changeset_comment_number_of_words  changeset_comment_naughty_words_count  \\\n",
+       "0                                  8                                      0   \n",
+       "1                                 18                                      0   \n",
+       "2                                  3                                      0   \n",
+       "3                                 35                                      0   \n",
+       "4                                  3                                      0   \n",
+       "\n",
+       "   changeset_bbox_area              ...               railway_old  route_old  \\\n",
+       "0                    0              ...                       0.0        0.0   \n",
+       "1           1091029462              ...                       0.0        0.0   \n",
+       "2                    0              ...                       0.0        0.0   \n",
+       "3                    0              ...                       0.0        0.0   \n",
+       "4                  448              ...                       0.0        0.0   \n",
+       "\n",
+       "   shop_old  sport_old  tourism_old  waterway_old  tag_values_popularity_min  \\\n",
+       "0       0.0        0.0          0.0           0.0                     0.0164   \n",
+       "1       0.0        0.0          0.0           0.0                     0.2896   \n",
+       "2       0.0        0.0          0.0           0.0                     0.0043   \n",
+       "3       0.0        0.0          0.0           0.0                     0.0221   \n",
+       "4       0.0        0.0          0.0           0.0                     0.3255   \n",
+       "\n",
+       "   tag_values_popularity_max  tag_values_popularity_mean  \\\n",
+       "0                     0.5083                      0.2623   \n",
+       "1                     0.2896                      0.2896   \n",
+       "2                     0.0043                      0.0043   \n",
+       "3                     0.0221                      0.0221   \n",
+       "4                     0.3255                      0.3255   \n",
+       "\n",
+       "   tag_values_popularity_stddev  \n",
+       "0                        0.2459  \n",
+       "1                        0.0000  \n",
+       "2                        0.0000  \n",
+       "3                        0.0000  \n",
+       "4                        0.0000  \n",
+       "\n",
+       "[5 rows x 115 columns]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "samples = pd.read_csv(path + 'training.csv')\n",
+    "samples.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_dissimilarity(first, second):\n",
+    "    dissimilarity = []\n",
+    "    for i in range(len(first)):\n",
+    "        if first[i] != second[i]: dissimilarity.append(i)\n",
+    "    return dissimilarity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "first = samples[samples['changeset_id'] == 47078737].iloc[0]\n",
+    "second = samples[samples['changeset_id'] == 47078765].iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Attribute</th>\n",
+       "      <th>First</th>\n",
+       "      <th>Second</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>changeset_id</td>\n",
+       "      <td>47078737.0</td>\n",
+       "      <td>47078765.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>changeset_bbox_area</td>\n",
+       "      <td>767.0</td>\n",
+       "      <td>1736.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>feature_area</td>\n",
+       "      <td>350.0</td>\n",
+       "      <td>403.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>feature_area_old</td>\n",
+       "      <td>350.0</td>\n",
+       "      <td>403.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             Attribute       First      Second\n",
+       "0         changeset_id  47078737.0  47078765.0\n",
+       "1  changeset_bbox_area       767.0      1736.0\n",
+       "2         feature_area       350.0       403.0\n",
+       "3     feature_area_old       350.0       403.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "indexes = get_dissimilarity(first.values, second.values)\n",
+    "result = []\n",
+    "for index in indexes:\n",
+    "    result.append([samples.columns[index], first.values[index], second.values[index]])\n",
+    "pd.DataFrame(result, columns=['Attribute', 'First', 'Second'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "test = samples[samples['changeset_id'] == 47078765].iloc[0].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "scores = []\n",
+    "for sample in samples.values:\n",
+    "    dissimilar = get_dissimilarity(sample, test)\n",
+    "    scores.append([sample[0], len(dissimilar)])\n",
+    "scores = sorted(scores, key=lambda x: x[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "47078765.0, 0\n",
+      "47078737.0, 4\n",
+      "47078698.0, 4\n",
+      "47078730.0, 4\n",
+      "47078746.0, 4\n",
+      "46690182.0, 17\n",
+      "47074749.0, 17\n",
+      "46569657.0, 18\n",
+      "47921947.0, 18\n",
+      "46575475.0, 18\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('\\n'.join(['{}, {}'.format(item[0], item[1]) for item in scores[:10]]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [conda root]",
+   "language": "python",
+   "name": "conda-root-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes: https://github.com/mapbox/gabbar/issues/54

---

- Dissimilarity score between samples is `0` when all attributes are the same.
- Dissimilarity score between samples is `1` when all attributes except changeset_id are same.
- Dissimilarity between changeset [47078737](https://osmcha.mapbox.com/47078737/) and changeset [47078730](https://osmcha.mapbox.com/47078730/) is `4` as the following four attribute values are different between the two.
    - changeset_id
    - changeset_bbox_area
    - feature_area
    - feature_area_old

---

cc: @anandthakker @geohacker @batpad 